### PR TITLE
Correct the `default` parameter value on bundle

### DIFF
--- a/action/action_test.go
+++ b/action/action_test.go
@@ -53,16 +53,16 @@ func mockBundle() *bundle.Bundle {
 		},
 		Parameters: map[string]bundle.ParameterDefinition{
 			"param_one": {
-				DefaultValue: "one",
+				Default: "one",
 			},
 			"param_two": {
-				DefaultValue: "two",
+				Default: "two",
 				Destination: &bundle.Location{
 					EnvironmentVariable: "PARAM_TWO",
 				},
 			},
 			"param_three": {
-				DefaultValue: "three",
+				Default: "three",
 				Destination: &bundle.Location{
 					Path: "/param/three",
 				},

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -138,7 +138,7 @@ func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interf
 		} else if def.Required {
 			return res, fmt.Errorf("parameter %q is required", name)
 		}
-		res[name] = def.DefaultValue
+		res[name] = def.Default
 	}
 	return res, nil
 }

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -107,20 +107,20 @@ func TestValuesOrDefaults(t *testing.T) {
 	b := &Bundle{
 		Parameters: map[string]ParameterDefinition{
 			"port": {
-				DataType:     "int",
-				DefaultValue: 1234,
+				DataType: "int",
+				Default:  1234,
 			},
 			"host": {
-				DataType:     "string",
-				DefaultValue: "localhost.localdomain",
+				DataType: "string",
+				Default:  "localhost.localdomain",
 			},
 			"enabled": {
-				DataType:     "bool",
-				DefaultValue: false,
+				DataType: "bool",
+				Default:  false,
 			},
 			"replicaCount": {
-				DataType:     "int",
-				DefaultValue: 3,
+				DataType: "int",
+				Default:  3,
 			},
 		},
 	}
@@ -151,8 +151,8 @@ func TestValuesOrDefaults_Required(t *testing.T) {
 				Required: true,
 			},
 			"enabled": {
-				DataType:     "bool",
-				DefaultValue: false,
+				DataType: "bool",
+				Default:  false,
 			},
 		},
 	}

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -10,7 +10,7 @@ import (
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {
 	DataType      string             `json:"type" mapstructure:"type"`
-	DefaultValue  interface{}        `json:"defaultValue,omitempty" mapstructure:"defaultValue"`
+	Default       interface{}        `json:"default,omitempty" mapstructure:"default"`
 	AllowedValues []interface{}      `json:"allowedValues,omitempty" mapstructure:"allowedValues"`
 	Required      bool               `json:"required,omitempty" mapstructure:"required"`
 	MinValue      *int               `json:"minValue,omitempty" mapstructure:"minValue"`

--- a/bundle/parameters_test.go
+++ b/bundle/parameters_test.go
@@ -41,12 +41,18 @@ func TestCanReadParameterDefinition(t *testing.T) {
 	description := "some description"
 	action0 := "action0"
 	action1 := "action1"
+	destinationEnvValue := "BACKEND_PORT"
+	destinationPathValue := "/some/path"
 
 	json := fmt.Sprintf(`{
 		"parameters": {
 			"test": {
 				"type": "%s",
-				"defaultValue": "%s",
+				"default": "%s",
+				"destination": {
+					"env": "%s",
+					"path": "%s"
+				},
 				"allowedValues": [ "%s", "%s" ],
 				"minValue": %d,
 				"maxValue": %d,
@@ -59,7 +65,8 @@ func TestCanReadParameterDefinition(t *testing.T) {
 			}
 		}
 	}`,
-		dataType, defaultValue, allowedValues0, allowedValues1,
+		dataType, defaultValue, destinationEnvValue, destinationPathValue,
+		allowedValues0, allowedValues1,
 		minValue, maxValue, minLength, maxLength, description,
 		action0, action1)
 
@@ -72,8 +79,14 @@ func TestCanReadParameterDefinition(t *testing.T) {
 	if p.DataType != dataType {
 		t.Errorf("Expected data type '%s' but got '%s'", dataType, p.DataType)
 	}
-	if p.DefaultValue != defaultValue {
-		t.Errorf("Expected default value '%s' but got '%s'", defaultValue, p.DefaultValue)
+	if p.Default != defaultValue {
+		t.Errorf("Expected default value '%s' but got '%s'", defaultValue, p.Default)
+	}
+	if p.Destination.EnvironmentVariable != destinationEnvValue {
+		t.Errorf("Expected destination environment value '%s' but got '%s'", destinationEnvValue, p.Destination.EnvironmentVariable)
+	}
+	if p.Destination.Path != destinationPathValue {
+		t.Errorf("Expected destination path value '%s' but got '%s'", destinationPathValue, p.Destination.Path)
 	}
 	if len(p.AllowedValues) != 2 {
 		t.Errorf("Expected 2 allowed values but got %d", len(p.AllowedValues))
@@ -114,7 +127,7 @@ func valueTestJSON(jsonRepresentation string) []byte {
 	return []byte(fmt.Sprintf(`{
 		"parameters": {
 			"test": {
-				"defaultValue": %s,
+				"default": %s,
 				"allowedValues": [ %s ]
 			}
 		}
@@ -160,21 +173,21 @@ func TestCanReadValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectString("default value", "some string", strDef.Parameters["test"].DefaultValue, t)
+	expectString("default value", "some string", strDef.Parameters["test"].Default, t)
 	expectString("allowed value", "some string", strDef.Parameters["test"].AllowedValues[0], t)
 
 	intDef, err := Unmarshal(valueTestJSON(intValue))
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectInt("default value", 123, intDef.Parameters["test"].DefaultValue, t)
+	expectInt("default value", 123, intDef.Parameters["test"].Default, t)
 	expectInt("allowed value", 123, intDef.Parameters["test"].AllowedValues[0], t)
 
 	boolDef, err := Unmarshal(valueTestJSON(boolValue))
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectBool("default value", true, boolDef.Parameters["test"].DefaultValue, t)
+	expectBool("default value", true, boolDef.Parameters["test"].Default, t)
 	expectBool("allowed value", true, boolDef.Parameters["test"].AllowedValues[0], t)
 }
 


### PR DESCRIPTION
The spec field for default parameter value change to `default` instead of `defaultValue`

Related deislabs/duffle#753