### PR TITLE
Add custom extensions to bundle struct

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -23,6 +23,10 @@ type Bundle struct {
 	Actions          map[string]Action              `json:"actions,omitempty" mapstructure:"actions"`
 	Parameters       map[string]ParameterDefinition `json:"parameters" mapstructure:"parameters"`
 	Credentials      map[string]Location            `json:"credentials" mapstructure:"credentials"`
+
+	// Custom extension metadata is a named collection of auxiliary data whose
+	// meaning is defined outside of the CNAB specification.
+	Custom map[string]interface{} `json:"custom" mapstructure:"custom"`
 }
 
 //Unmarshal unmarshals a Bundle that was not signed.

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -12,7 +12,8 @@ func TestReadTopLevelProperties(t *testing.T) {
 		"name": "foo",
 		"version": "1.0",
 		"images": {},
-		"credentials": {}
+		"credentials": {},
+		"custom": {}
 	}`
 	bundle, err := Unmarshal([]byte(json))
 	if err != nil {
@@ -29,6 +30,9 @@ func TestReadTopLevelProperties(t *testing.T) {
 	}
 	if len(bundle.Credentials) != 0 {
 		t.Errorf("Expected no credentials, got %d", len(bundle.Credentials))
+	}
+	if len(bundle.Custom) != 0 {
+		t.Errorf("Expected no custom extensions, got %d", len(bundle.Custom))
 	}
 }
 
@@ -203,4 +207,42 @@ func TestValidateBundle_RequiresInvocationImage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestReadCustomExtensions(t *testing.T) {
+	data, err := ioutil.ReadFile("../testdata/bundles/foo.json")
+	if err != nil {
+		t.Errorf("cannot read bundle file: %v", err)
+	}
+
+	bundle, err := Unmarshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(bundle.Custom) != 2 {
+		t.Errorf("Expected 2 custom extensions, got %d", len(bundle.Custom))
+	}
+
+	duffleExtI, ok := bundle.Custom["com.example.duffle-bag"]
+	if !ok {
+		t.Fatal("Expected the com.example.duffle-bag extension")
+	}
+	duffleExt, ok := duffleExtI.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected the com.example.duffle-bag to be of type map[string]interface{} but got %T ", duffleExtI)
+	}
+	assert.Equal(t, "PNG", duffleExt["iconType"])
+	assert.Equal(t, "https://example.com/icon.png", duffleExt["icon"])
+
+	backupExtI, ok := bundle.Custom["com.example.backup-preferences"]
+	if !ok {
+		t.Fatal("Expected the com.example.backup-preferences extension")
+	}
+	backupExt, ok := backupExtI.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected the com.example.backup-preferences to be of type map[string]interface{} but got %T ", backupExtI)
+	}
+	assert.Equal(t, true, backupExt["enabled"])
+	assert.Equal(t, "daily", backupExt["frequency"])
 }

--- a/testdata/bundles/foo.json
+++ b/testdata/bundles/foo.json
@@ -41,5 +41,15 @@
             "path": "pquux",
             "env": "equux"
         }
+    },
+    "custom": {
+        "com.example.duffle-bag": {
+            "icon": "https://example.com/icon.png",
+            "iconType": "PNG"
+        },
+        "com.example.backup-preferences": {
+            "enabled": true,
+            "frequency": "daily"
+        }
     }
 }


### PR DESCRIPTION
This adds the custom extensions section to Bundle from the CNAB Spec as part of the push to close gaps for 1.0. See https://github.com/deislabs/cnab-spec/blob/master/101-bundle-json.md#custom-extensions from the CNAB Spec.

