### PR TITLE
Add missing omitempty to Bundle.Custom

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -26,7 +26,7 @@ type Bundle struct {
 
 	// Custom extension metadata is a named collection of auxiliary data whose
 	// meaning is defined outside of the CNAB specification.
-	Custom map[string]interface{} `json:"custom" mapstructure:"custom"`
+	Custom map[string]interface{} `json:"custom,omitempty" mapstructure:"custom"`
 }
 
 //Unmarshal unmarshals a Bundle that was not signed.


### PR DESCRIPTION
This is a follow-up to https://github.com/deislabs/cnab-go/pull/21/files#r289733051 to ensure that custom isn't serialized when empty.