### PR TITLE
Updating credentials to use a struct with more than location

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,9 +34,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:42e8c2456d7ec0f31e182c20022e74324c4da2cb3bd9069ff9b131fe33466308"
+  digest = "1:85adecf1dbfae5769cc62a8bcea6498f8e9f0e2452e4e6686eb36fa4428a5a6e"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
   pruneopts = "NUT"
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
@@ -56,6 +59,7 @@
     "github.com/docker/go/canonical/json",
     "github.com/oklog/ulid",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
     "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -41,14 +41,18 @@ func mockBundle() *bundle.Bundle {
 				BaseImage: bundle.BaseImage{Image: "foo/bar:0.1.0", ImageType: "docker"},
 			},
 		},
-		Credentials: map[string]bundle.Location{
+		Credentials: map[string]bundle.Credential{
 			"secret_one": {
-				EnvironmentVariable: "SECRET_ONE",
-				Path:                "/foo/bar",
+				Location: bundle.Location{
+					EnvironmentVariable: "SECRET_ONE",
+					Path:                "/foo/bar",
+				},
 			},
 			"secret_two": {
-				EnvironmentVariable: "SECRET_TWO",
-				Path:                "/secret/two",
+				Location: bundle.Location{
+					EnvironmentVariable: "SECRET_TWO",
+					Path:                "/secret/two",
+				},
 			},
 		},
 		Parameters: map[string]bundle.ParameterDefinition{

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -22,7 +22,7 @@ type Bundle struct {
 	Images           map[string]Image               `json:"images" mapstructure:"images"`
 	Actions          map[string]Action              `json:"actions,omitempty" mapstructure:"actions"`
 	Parameters       map[string]ParameterDefinition `json:"parameters" mapstructure:"parameters"`
-	Credentials      map[string]Location            `json:"credentials" mapstructure:"credentials"`
+	Credentials      map[string]Credential          `json:"credentials" mapstructure:"credentials"`
 
 	// Custom extension metadata is a named collection of auxiliary data whose
 	// meaning is defined outside of the CNAB specification.

--- a/bundle/credentials.go
+++ b/bundle/credentials.go
@@ -1,0 +1,8 @@
+package bundle
+
+// Credential represents the definition of a CNAB credential
+type Credential struct {
+	Location    `json:",squash" mapstructure:",squash"`
+	Description string `json:"description,omitempty" mapstructure:"description"`
+	Required    bool   `json:"required,omitempty" mapstructure:"required"`
+}

--- a/bundle/credentials.go
+++ b/bundle/credentials.go
@@ -2,7 +2,7 @@ package bundle
 
 // Credential represents the definition of a CNAB credential
 type Credential struct {
-	Location    `json:",squash" mapstructure:",squash"`
+	Location    `mapstructure:",squash"`
 	Description string `json:"description,omitempty" mapstructure:"description"`
 	Required    bool   `json:"required,omitempty" mapstructure:"required"`
 }

--- a/bundle/credentials_test.go
+++ b/bundle/credentials_test.go
@@ -1,0 +1,104 @@
+package bundle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompleteCredDefinition(t *testing.T) {
+	payload := `{
+		"credentials": {
+			"something": { 
+				"description" : "wicked this way comes",
+				"path" : "/cnab/app/a/credential",
+				"required" : true
+			}
+		}
+	}`
+
+	definitions, err := Unmarshal([]byte(payload))
+	require.NoError(t, err, "given credentials payload was valid json")
+
+	something, ok := definitions.Credentials["something"]
+	assert.True(t, ok, "should have found the `something` entry")
+
+	assert.Equal(t, "/cnab/app/a/credential", something.Path, "did not contain the expected path")
+	assert.Equal(t, "wicked this way comes", something.Description, "did not contain the expected description")
+
+}
+
+func TestHandleMultipleCreds(t *testing.T) {
+	payload := `{
+		"credentials": {
+			"something": { },
+			"else": { }
+		}
+	}`
+
+	definitions, err := Unmarshal([]byte(payload))
+	require.NoError(t, err, "given credentials payload was valid json")
+
+	assert.Equal(t, 2, len(definitions.Credentials), "credentials should have contained two entries")
+
+	_, ok := definitions.Credentials["something"]
+	assert.True(t, ok, "should have found the `something` entry")
+
+	_, ok = definitions.Credentials["else"]
+	assert.True(t, ok, "should have found the `else` entry")
+
+}
+
+func TestNotRequiredIsFalse(t *testing.T) {
+	payload := `{
+		"credentials": {
+			"something": { 
+				"path" : "/cnab/app/a/credential",
+				"required" : false
+			}
+		}
+	}`
+
+	definitions, err := Unmarshal([]byte(payload))
+	require.NoError(t, err, "given credentials payload was valid json")
+
+	something, ok := definitions.Credentials["something"]
+	assert.True(t, ok, "should have found the credential")
+	assert.False(t, something.Required, "required was set to `false` in the json")
+}
+
+func TestUnspecifiedRequiredIsFalse(t *testing.T) {
+	payload := `{
+		"credentials": {
+			"something": { 
+				"path" : "/cnab/app/a/credential"
+			}
+		}
+	}`
+
+	definitions, err := Unmarshal([]byte(payload))
+	require.NoError(t, err, "given credentials payload was valid json")
+
+	something, ok := definitions.Credentials["something"]
+	assert.True(t, ok, "should have found the credential")
+	assert.False(t, something.Required, "required was unspecified in the json")
+}
+
+func TestRequiredIsTrue(t *testing.T) {
+	payload := `{
+		"credentials": {
+			"something": { 
+				"path" : "/cnab/app/a/credential",
+				"required" : true
+			}
+		}
+	}`
+
+	definitions, err := Unmarshal([]byte(payload))
+	require.NoError(t, err, "given credentials payload was valid json")
+
+	something, ok := definitions.Credentials["something"]
+	assert.True(t, ok, "should have found the credential")
+	assert.True(t, something.Required, "required was set to `true` in the json")
+}

--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -83,7 +83,7 @@ func Load(path string) (*CredentialSet, error) {
 //
 // It is allowed for spec to specify both an env var and a file. In such case, if
 // the givn set provides either, it will be considered valid.
-func Validate(given Set, spec map[string]bundle.Location) error {
+func Validate(given Set, spec map[string]bundle.Credential) error {
 	for name := range spec {
 		if !isValidCred(given, name) {
 			return fmt.Errorf("bundle requires credential for %s", name)

--- a/credentials/credentialset_test.go
+++ b/credentials/credentialset_test.go
@@ -52,18 +52,25 @@ func TestCredentialSet(t *testing.T) {
 }
 
 func TestCredentialSet_Expand(t *testing.T) {
+
 	b := &bundle.Bundle{
 		Name: "knapsack",
-		Credentials: map[string]bundle.Location{
+		Credentials: map[string]bundle.Credential{
 			"first": {
-				EnvironmentVariable: "FIRST_VAR",
+				Location: bundle.Location{
+					EnvironmentVariable: "FIRST_VAR",
+				},
 			},
 			"second": {
-				Path: "/second/path",
+				Location: bundle.Location{
+					Path: "/second/path",
+				},
 			},
 			"third": {
-				EnvironmentVariable: "/THIRD_VAR",
-				Path:                "/third/path",
+				Location: bundle.Location{
+					EnvironmentVariable: "/THIRD_VAR",
+					Path:                "/third/path",
+				},
 			},
 		},
 	}
@@ -113,9 +120,11 @@ func TestCredentialSet_Merge(t *testing.T) {
 func TestCredentialSetMissingCred(t *testing.T) {
 	b := &bundle.Bundle{
 		Name: "knapsack",
-		Credentials: map[string]bundle.Location{
+		Credentials: map[string]bundle.Credential{
 			"first": {
-				EnvironmentVariable: "FIRST_VAR",
+				Location: bundle.Location{
+					EnvironmentVariable: "FIRST_VAR",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Per the spec, credentials have more attributes than just location, so this PR changes the definition around. Originally, this was just adding the `required` field but we also didn't have description. 

Closes #27 