### PR TITLE
Step One: Introduce Outputs and "Fields" and "Required" to Parameters

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -71,15 +71,20 @@ func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.Invoca
 
 	// Quick verification that no params were passed that are not actual legit params.
 	for key := range c.Parameters {
-		if _, ok := c.Bundle.Parameters[key]; !ok {
+		if _, ok := c.Bundle.Parameters.Fields[key]; !ok {
 			return nil, fmt.Errorf("undefined parameter %q", key)
 		}
 	}
 
-	for k, param := range c.Bundle.Parameters {
+	requiredMap := map[string]struct{}{}
+	for _, key := range c.Bundle.Parameters.Required {
+		requiredMap[key] = struct{}{}
+	}
+	for k, param := range c.Bundle.Parameters.Fields {
 		rawval, ok := c.Parameters[k]
 		if !ok {
-			if param.Required && appliesToAction(action, param) {
+			_, required := requiredMap[k]
+			if required && appliesToAction(action, param) {
 				return nil, fmt.Errorf("missing required parameter %q for action %q", k, action)
 			}
 			continue

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -55,20 +55,22 @@ func mockBundle() *bundle.Bundle {
 				},
 			},
 		},
-		Parameters: map[string]bundle.ParameterDefinition{
-			"param_one": {
-				Default: "one",
-			},
-			"param_two": {
-				Default: "two",
-				Destination: &bundle.Location{
-					EnvironmentVariable: "PARAM_TWO",
+		Parameters: bundle.ParametersDefinition{
+			Fields: map[string]bundle.ParameterDefinition{
+				"param_one": {
+					Default: "one",
 				},
-			},
-			"param_three": {
-				Default: "three",
-				Destination: &bundle.Location{
-					Path: "/param/three",
+				"param_two": {
+					Default: "two",
+					Destination: &bundle.Location{
+						EnvironmentVariable: "PARAM_TWO",
+					},
+				},
+				"param_three": {
+					Default: "three",
+					Destination: &bundle.Location{
+						Path: "/param/three",
+					},
 				},
 			},
 		},
@@ -151,7 +153,8 @@ func TestOpFromClaim_UndefinedParams(t *testing.T) {
 func TestOpFromClaim_MissingRequiredParameter(t *testing.T) {
 	now := time.Now()
 	b := mockBundle()
-	b.Parameters["param_one"] = bundle.ParameterDefinition{Required: true}
+	b.Parameters.Required = []string{"param_one"}
+	b.Parameters.Fields["param_one"] = bundle.ParameterDefinition{}
 
 	c := &claim.Claim{
 		Created:  now,
@@ -180,10 +183,10 @@ func TestOpFromClaim_MissingRequiredParamSpecificToAction(t *testing.T) {
 	now := time.Now()
 	b := mockBundle()
 	// Add a required parameter only defined for the test action
-	b.Parameters["param_test"] = bundle.ParameterDefinition{
-		ApplyTo:  []string{"test"},
-		Required: true,
+	b.Parameters.Fields["param_test"] = bundle.ParameterDefinition{
+		ApplyTo: []string{"test"},
 	}
+	b.Parameters.Required = []string{"param_test"}
 	c := &claim.Claim{
 		Created:  now,
 		Modified: now,

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -13,16 +13,17 @@ import (
 
 // Bundle is a CNAB metadata document
 type Bundle struct {
-	Name             string                         `json:"name" mapstructure:"name"`
-	Version          string                         `json:"version" mapstructure:"version"`
-	Description      string                         `json:"description" mapstructure:"description"`
-	Keywords         []string                       `json:"keywords,omitempty" mapstructure:"keywords"`
-	Maintainers      []Maintainer                   `json:"maintainers,omitempty" mapstructure:"maintainers"`
-	InvocationImages []InvocationImage              `json:"invocationImages" mapstructure:"invocationImages"`
-	Images           map[string]Image               `json:"images" mapstructure:"images"`
-	Actions          map[string]Action              `json:"actions,omitempty" mapstructure:"actions"`
-	Parameters       map[string]ParameterDefinition `json:"parameters" mapstructure:"parameters"`
-	Credentials      map[string]Credential          `json:"credentials" mapstructure:"credentials"`
+	Name             string                `json:"name" mapstructure:"name"`
+	Version          string                `json:"version" mapstructure:"version"`
+	Description      string                `json:"description" mapstructure:"description"`
+	Keywords         []string              `json:"keywords,omitempty" mapstructure:"keywords"`
+	Maintainers      []Maintainer          `json:"maintainers,omitempty" mapstructure:"maintainers"`
+	InvocationImages []InvocationImage     `json:"invocationImages" mapstructure:"invocationImages"`
+	Images           map[string]Image      `json:"images" mapstructure:"images"`
+	Actions          map[string]Action     `json:"actions,omitempty" mapstructure:"actions"`
+	Parameters       ParametersDefinition  `json:"parameters" mapstructure:"parameters"`
+	Credentials      map[string]Credential `json:"credentials" mapstructure:"credentials"`
+	Outputs          OutputsDefinition     `json:"outputs" mapstructure:"outputs"`
 
 	// Custom extension metadata is a named collection of auxiliary data whose
 	// meaning is defined outside of the CNAB specification.
@@ -130,8 +131,13 @@ type Action struct {
 
 // ValuesOrDefaults returns parameter values or the default parameter values
 func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+	requiredMap := map[string]struct{}{}
+	for _, key := range b.Parameters.Required {
+		requiredMap[key] = struct{}{}
+	}
 	res := map[string]interface{}{}
-	for name, def := range b.Parameters {
+
+	for name, def := range b.Parameters.Fields {
 		if val, ok := vals[name]; ok {
 			if err := def.ValidateParameterValue(val); err != nil {
 				return res, fmt.Errorf("can't use %v as value of %s: %s", val, name, err)
@@ -139,7 +145,7 @@ func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interf
 			typedVal := def.CoerceValue(val)
 			res[name] = typedVal
 			continue
-		} else if def.Required {
+		} else if _, ok := requiredMap[name]; ok {
 			return res, fmt.Errorf("parameter %q is required", name)
 		}
 		res[name] = def.Default

--- a/bundle/outputs.go
+++ b/bundle/outputs.go
@@ -1,0 +1,20 @@
+package bundle
+
+type OutputsDefinition struct {
+	Fields   map[string]OutputDefinition `json:"fields" mapstructure:"fields"`
+	Required []string                    `json:"required,omitempty" mapstructure:"required,omitempty"`
+}
+
+type OutputDefinition struct {
+	DataType      string             `json:"type" mapstructure:"type"`
+	Default       interface{}        `json:"default,omitempty" mapstructure:"default"`
+	AllowedValues []interface{}      `json:"allowedValues,omitempty" mapstructure:"allowedValues"`
+	MinValue      *int               `json:"minValue,omitempty" mapstructure:"minValue"`
+	MaxValue      *int               `json:"maxValue,omitempty" mapstructure:"maxValue"`
+	MinLength     *int               `json:"minLength,omitempty" mapstructure:"minLength"`
+	MaxLength     *int               `json:"maxLength,omitempty" mapstructure:"maxLength"`
+	Metadata      *ParameterMetadata `json:"metadata,omitempty" mapstructure:"metadata"`
+	Path          string             `json:"path,omitemtpty" mapstructure:"path,omitempty"`
+	ApplyTo       []string           `json:"apply-to,omitempty" mapstructure:"apply-to,omitempty"`
+	Sensitive     bool               `json:"sensitive,omitempty" mapstructure:"sensitive,omitempty"`
+}

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -7,12 +7,16 @@ import (
 	"strings"
 )
 
+type ParametersDefinition struct {
+	Fields   map[string]ParameterDefinition `json:"fields" mapstructure:"fields"`
+	Required []string                       `json:"required,omitempty" mapstructure:"required,omitempty"`
+}
+
 // ParameterDefinition defines a single parameter for a CNAB bundle
 type ParameterDefinition struct {
 	DataType      string             `json:"type" mapstructure:"type"`
 	Default       interface{}        `json:"default,omitempty" mapstructure:"default"`
 	AllowedValues []interface{}      `json:"allowedValues,omitempty" mapstructure:"allowedValues"`
-	Required      bool               `json:"required,omitempty" mapstructure:"required"`
 	MinValue      *int               `json:"minValue,omitempty" mapstructure:"minValue"`
 	MaxValue      *int               `json:"maxValue,omitempty" mapstructure:"maxValue"`
 	MinLength     *int               `json:"minLength,omitempty" mapstructure:"minLength"`

--- a/bundle/parameters_test.go
+++ b/bundle/parameters_test.go
@@ -10,21 +10,23 @@ import (
 func TestCanReadParameterNames(t *testing.T) {
 	json := `{
 		"parameters": {
-			"foo": { },
-			"bar": { }
+			"fields" : {
+				"foo": { },
+				"bar": { }
+			}
 		}
 	}`
 	definitions, err := Unmarshal([]byte(json))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(definitions.Parameters) != 2 {
-		t.Fatalf("Expected 2 parameter definitons, got %d", len(definitions.Parameters))
+	if len(definitions.Parameters.Fields) != 2 {
+		t.Fatalf("Expected 2 parameter definitons, got %d", len(definitions.Parameters.Fields))
 	}
-	if _, ok := definitions.Parameters["foo"]; !ok {
+	if _, ok := definitions.Parameters.Fields["foo"]; !ok {
 		t.Errorf("Expected an entry with name 'foo' but didn't get one")
 	}
-	if _, ok := definitions.Parameters["bar"]; !ok {
+	if _, ok := definitions.Parameters.Fields["bar"]; !ok {
 		t.Errorf("Expected an entry with name 'bar' but didn't get one")
 	}
 }
@@ -46,22 +48,24 @@ func TestCanReadParameterDefinition(t *testing.T) {
 
 	json := fmt.Sprintf(`{
 		"parameters": {
-			"test": {
-				"type": "%s",
-				"default": "%s",
-				"destination": {
-					"env": "%s",
-					"path": "%s"
-				},
-				"allowedValues": [ "%s", "%s" ],
-				"minValue": %d,
-				"maxValue": %d,
-				"minLength": %d,
-				"maxLength": %d,
-				"metadata": {
-					"description": "%s"
-				},
-				"applyTo": [ "%s", "%s" ]
+			"fields" : {
+				"test": {
+					"type": "%s",
+					"default": "%s",
+					"destination": {
+						"env": "%s",
+						"path": "%s"
+					},
+					"allowedValues": [ "%s", "%s" ],
+					"minValue": %d,
+					"maxValue": %d,
+					"minLength": %d,
+					"maxLength": %d,
+					"metadata": {
+						"description": "%s"
+					},
+					"applyTo": [ "%s", "%s" ]
+				}
 			}
 		}
 	}`,
@@ -75,7 +79,7 @@ func TestCanReadParameterDefinition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	p := definitions.Parameters["test"]
+	p := definitions.Parameters.Fields["test"]
 	if p.DataType != dataType {
 		t.Errorf("Expected data type '%s' but got '%s'", dataType, p.DataType)
 	}
@@ -126,9 +130,11 @@ func TestCanReadParameterDefinition(t *testing.T) {
 func valueTestJSON(jsonRepresentation string) []byte {
 	return []byte(fmt.Sprintf(`{
 		"parameters": {
-			"test": {
-				"default": %s,
-				"allowedValues": [ %s ]
+			"fields" : {
+				"test": {
+					"default": %s,
+					"allowedValues": [ %s ]
+				}
 			}
 		}
 	}`, jsonRepresentation, jsonRepresentation))
@@ -173,22 +179,22 @@ func TestCanReadValues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectString("default value", "some string", strDef.Parameters["test"].Default, t)
-	expectString("allowed value", "some string", strDef.Parameters["test"].AllowedValues[0], t)
+	expectString("default value", "some string", strDef.Parameters.Fields["test"].Default, t)
+	expectString("allowed value", "some string", strDef.Parameters.Fields["test"].AllowedValues[0], t)
 
 	intDef, err := Unmarshal(valueTestJSON(intValue))
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectInt("default value", 123, intDef.Parameters["test"].Default, t)
-	expectInt("allowed value", 123, intDef.Parameters["test"].AllowedValues[0], t)
+	expectInt("default value", 123, intDef.Parameters.Fields["test"].Default, t)
+	expectInt("allowed value", 123, intDef.Parameters.Fields["test"].AllowedValues[0], t)
 
 	boolDef, err := Unmarshal(valueTestJSON(boolValue))
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectBool("default value", true, boolDef.Parameters["test"].Default, t)
-	expectBool("allowed value", true, boolDef.Parameters["test"].AllowedValues[0], t)
+	expectBool("default value", true, boolDef.Parameters.Fields["test"].Default, t)
+	expectBool("allowed value", true, boolDef.Parameters.Fields["test"].AllowedValues[0], t)
 }
 
 func TestValidateStringParameterValue_AnyAllowed(t *testing.T) {


### PR DESCRIPTION
This PR is the first step in updating cnab-go to match the spec with regard to Parameters and Outptus. The overall change is pretty large when you consider adding JSON Schema, so I'm opening this PR first and will do a follow-on with the JSON schema in the interest of making things easy to review. This PR specifically introduces an `outputs` section to the bundle definition with corresponding structs, and introduces both `fields` and `required` fields to the parameters definition. 

Part of #17 and #14