### PR TITLE
Update README file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+We have [good first issues][good-first-issue] for new contributors and [help wanted][help-wanted] issues for our other contributors.
+
+* `good first issue` has extra information to help you make your first contribution.
+* `help wanted` are issues suitable for someone who isn't a core maintainer.
+
+Maintainers will do our best regularly make new issues for you to solve and then help out as you work on them. 💖
+
+# Philosophy
+PRs are most welcome!
+
+* If there isn't an issue for your PR, please make an issue first and explain the problem or motivation for
+the change you are proposing. When the solution isn't straightforward, for example "Implement missing command X",
+then also outline your proposed solution. Your PR will go smoother if the solution is agreed upon before you've
+spent a lot of time implementing it.
+  * It's OK to submit a PR directly for problems such as misspellings or other things where the motivation/problem is
+    unambiguous.
+* If you aren't sure about your solution yet, put WIP in the title or open as a draft PR so that people know to be nice and 
+wait for you to finish before commenting.
+* Try to keep your PRs to a single task. Please don't tackle multiple things in a single PR if possible. Otherwise, grouping related changes into commits will help us out a bunch when reviewing!
+* We encourage "follow-on PRs". If the core of your changes are good, and it won't hurt to do more of
+the changes later, we like to merge early, and keep working on it in another PR so that others can build
+on top of your work.
+
+When you're ready to get started, we recommend the following workflow:
+
+```
+$ go build ./...
+$ go test ./...
+$ golangci-lint run --config ./golangci.yml
+```
+
+We currently use [dep](https://github.com/golang/dep) for dependency management.
+
+# Cutting a Release
+
+Our CI system watches for tags, and when a tag is pushed, it executes the
+publish target in the Makefile. When you are asked to cut a new release,
+here is the process:
+
+1. Figure out the correct version number, we follow [semver](semver.org) and
+    have a funny [release naming scheme][release-name]:
+    * Bump the major segment if there are any breaking changes.
+    * Bump the minor segment if there are new features only.
+    * Bump the patch segment if there are bug fixes only.
+    * Bump the build segment (version-prerelease.BUILDTAG+releasename) if you only
+      fixed something in the build, but the final binaries are the same.
+1. Figure out if the release name (version-prerelease.buildtag+RELEASENAME) should
+    change.
+    
+    * Keep the release name the same if it is just a build tag or patch bump.
+    * It is a new release name for major and minor bumps.
+    
+    If you need a new release name, it must be conversation with the team.
+    [Release naming scheme][release-name] explains the meaning behind the
+    release names.
+1. Ensure that the master CI build is passing, then make the tag and push it.
+
+    ```
+    git checkout master
+    git pull
+    git tag VERSION -a -m ""
+    git push --tags
+    ```
+
+1. Generate some release notes and put them into the release on GitHub.
+    The following command gives you a list of all the merged pull requests:
+
+    ```
+    git log --oneline OLDVERSION..NEWVERSION  | grep "#" > gitlog.txt
+    ```
+
+    You need to go through that and make a bulleted list of features
+    and fixes with the PR titles and links to the PR. If you come up with an
+    easier way of doing this, please submit a PR to update these instructions. 😅
+
+    ```
+    # Features
+    * PR TITLE (#PR NUMBER)
+
+    # Fixes
+    * PR TITLE (#PR NUMBER)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,12 @@ $ golangci-lint run --config ./golangci.yml
 
 We currently use [dep](https://github.com/golang/dep) for dependency management.
 
+[good-first-issue]: https://github.com/deislabs/cnab-go/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+[help-wanted]: https://github.com/deislabs/cnab-go/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22
+
 # Cutting a Release
 
-Our CI system watches for tags, and when a tag is pushed, it executes the
-publish target in the Makefile. When you are asked to cut a new release,
-here is the process:
+When you are asked to cut a new release, here is the process:
 
 1. Figure out the correct version number, we follow [semver](semver.org) and
     have a funny [release naming scheme][release-name]:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,14 @@
+# Governance
+
+## Project Maintainers
+[Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating CNAB-go, a library for the [CNAB spec](https://github.com/deislabs/cnab-spec). Final decisions on the project reside with the project maintainers.
+
+Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
+
+New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers.
+
+A maintainer may step down by submitting an [issue](https://github.com/deislabs/cnab-go/issues/new) stating their intent.
+
+## Code of Conduct
+This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # cnab-go
 
-CNAB packages for Go, extracted from Duffle.
+cnab-go is a library for building [CNAB](https://github.com/deislabs/cnab-spec) clients. It provides the building blocks relevant to the CNAB specification so that you may build tooling without needing to implement all aspects of the CNAB specification.
 
-We highly recommend you _do not_ take a dependency on this package, as it's currently in a very early, experimental state.
+cnab-go is currently being used by [Docker App](https://github.com/docker/app), [Duffle](https://github.com/deislabs/duffle), and [Porter](https://github.com/deislabs/porter). If you'd like to see your CNAB project listed here, please submit a PR.
 
-```
-$ go build ./...
-$ go test ./...
-$ golangci-lint run --config ./golangci.yml
-```
+cnab-go is [maintained](GOVERNANCE.md) by the CNAB community. We sometimes discuss cnab-go issues during the [bi-weekly CNAB community  meeting](https://hackmd.io/s/SyGcBcwQ4), but we encourage open communication via our [issue](https://github.com/deislabs/cnab-go/issues) queue and via [PRs](https://github.com/deislabs/cnab-go/pulls). If you are interested in contributing to cnab-go, please refer to our [contributing](CONTRIBUTING.md) guidelines.


### PR DESCRIPTION
This PR updates the README.md to remove the language about experimental-ness and the wording to not take a dependency on cnab-go. It also adds a CONTRIBUTING.md and a GOVERNANCE.md file, inspired by Porter and Duffle. 

It also defines release versioning / tagging. 

Closes #13 and #16 