### PR TITLE
Reintroduce ConvertValue(interface{})

### DIFF
--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -2,6 +2,8 @@ package definition
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/qri-io/jsonschema"
@@ -106,4 +108,27 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 		wrapperType: (*wrapperType)(s),
 	}
 	return json.Unmarshal(data, &wrapper)
+}
+
+func (s *Schema) ConvertValue(val string) (interface{}, error) {
+	dataType, ok, err := s.GetType()
+	if !ok {
+		return nil, errors.Wrapf(err, "unable to determine type: %v", s.Type)
+	}
+	switch dataType {
+	case "string":
+		return val, nil
+	case "integer":
+		return strconv.Atoi(val)
+	case "boolean":
+		if strings.ToLower(val) == "true" {
+			return true, nil
+		} else if strings.ToLower(val) == "false" {
+			return false, nil
+		} else {
+			return false, errors.Errorf("%q is not a valid boolean", val)
+		}
+	default:
+		return nil, errors.New("invalid definition")
+	}
 }

--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -110,6 +110,8 @@ func (s *Schema) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &wrapper)
 }
 
+// ConvertValue attempts to convert the given string value to the type from the
+// definition. Note: this is only applicable to string, number, integer and boolean types
 func (s *Schema) ConvertValue(val string) (interface{}, error) {
 	dataType, ok, err := s.GetType()
 	if !ok {
@@ -118,6 +120,12 @@ func (s *Schema) ConvertValue(val string) (interface{}, error) {
 	switch dataType {
 	case "string":
 		return val, nil
+	case "number":
+		num, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to convert %s to number", val)
+		}
+		return num, nil
 	case "integer":
 		return strconv.Atoi(val)
 	case "boolean":

--- a/bundle/definition/schema_test.go
+++ b/bundle/definition/schema_test.go
@@ -295,4 +295,43 @@ func TestConvertValue(t *testing.T) {
 
 	_, err = pd.ConvertValue("onetwothree")
 	is.Error(err)
+
+	pd.Type = "number"
+	out, err = pd.ConvertValue("123")
+	is.NoError(err)
+	is.Equal(float64(123), out.(float64))
+
+	out, err = pd.ConvertValue("5.5")
+	is.NoError(err)
+	is.Equal(5.5, out.(float64))
+
+	out, err = pd.ConvertValue("nope")
+	is.Error(err)
+
+	pd.Type = "array"
+	out, err = pd.ConvertValue("nope")
+	is.Error(err)
+
+	out, err = pd.ConvertValue("123")
+	is.Error(err)
+
+	out, err = pd.ConvertValue("true")
+	is.Error(err)
+
+	out, err = pd.ConvertValue("123.5")
+	is.Error(err)
+
+	pd.Type = "object"
+	out, err = pd.ConvertValue("nope")
+	is.Error(err)
+
+	out, err = pd.ConvertValue("123")
+	is.Error(err)
+
+	out, err = pd.ConvertValue("true")
+	is.Error(err)
+
+	out, err = pd.ConvertValue("123.5")
+	is.Error(err)
+
 }

--- a/bundle/definition/schema_test.go
+++ b/bundle/definition/schema_test.go
@@ -269,3 +269,30 @@ func valueTestJSON(kind, def, enum string) []byte {
 		"enum": [ %s ]
 	}`, kind, def, enum))
 }
+
+func TestConvertValue(t *testing.T) {
+	pd := Schema{
+		Type: "boolean",
+	}
+	is := assert.New(t)
+
+	out, _ := pd.ConvertValue("true")
+	is.True(out.(bool))
+	out, _ = pd.ConvertValue("false")
+	is.False(out.(bool))
+	out, _ = pd.ConvertValue("barbeque")
+	is.False(out.(bool))
+
+	pd.Type = "string"
+	out, err := pd.ConvertValue("hello")
+	is.NoError(err)
+	is.Equal("hello", out.(string))
+
+	pd.Type = "integer"
+	out, err = pd.ConvertValue("123")
+	is.NoError(err)
+	is.Equal(123, out.(int))
+
+	_, err = pd.ConvertValue("onetwothree")
+	is.Error(err)
+}

--- a/bundle/definition/schema_test.go
+++ b/bundle/definition/schema_test.go
@@ -305,33 +305,33 @@ func TestConvertValue(t *testing.T) {
 	is.NoError(err)
 	is.Equal(5.5, out.(float64))
 
-	out, err = pd.ConvertValue("nope")
+	_, err = pd.ConvertValue("nope")
 	is.Error(err)
 
 	pd.Type = "array"
-	out, err = pd.ConvertValue("nope")
+	_, err = pd.ConvertValue("nope")
 	is.Error(err)
 
-	out, err = pd.ConvertValue("123")
+	_, err = pd.ConvertValue("123")
 	is.Error(err)
 
-	out, err = pd.ConvertValue("true")
+	_, err = pd.ConvertValue("true")
 	is.Error(err)
 
-	out, err = pd.ConvertValue("123.5")
+	_, err = pd.ConvertValue("123.5")
 	is.Error(err)
 
 	pd.Type = "object"
-	out, err = pd.ConvertValue("nope")
+	_, err = pd.ConvertValue("nope")
 	is.Error(err)
 
-	out, err = pd.ConvertValue("123")
+	_, err = pd.ConvertValue("123")
 	is.Error(err)
 
-	out, err = pd.ConvertValue("true")
+	_, err = pd.ConvertValue("true")
 	is.Error(err)
 
-	out, err = pd.ConvertValue("123.5")
+	_, err = pd.ConvertValue("123.5")
 	is.Error(err)
 
 }


### PR DESCRIPTION
This PR re-introduces the ConvertValue(interface{}) method, but relocates it to
the definitions package.

The method was removed during the refactor since the types can be more than the simple types before, but was added back for convenience.  It only works on number, integer, boolean or string types. Others return an error.