### PR TITLE
Fix a nil pointer deference in bundle.ValuesOrDefaults

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -140,11 +140,16 @@ type Action struct {
 
 // ValuesOrDefaults returns parameter values or the default parameter values
 func ValuesOrDefaults(vals map[string]interface{}, b *Bundle) (map[string]interface{}, error) {
+	res := map[string]interface{}{}
+
+	if b.Parameters == nil {
+		return res, nil
+	}
+
 	requiredMap := map[string]struct{}{}
 	for _, key := range b.Parameters.Required {
 		requiredMap[key] = struct{}{}
 	}
-	res := map[string]interface{}{}
 
 	for name, def := range b.Parameters.Fields {
 		s, ok := b.Definitions[def.Definition]

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -157,6 +157,15 @@ func TestValuesOrDefaults(t *testing.T) {
 	is.Error(err)
 }
 
+func TestValuesOrDefaults_NoParameter(t *testing.T) {
+	is := assert.New(t)
+	vals := map[string]interface{}{}
+	b := &Bundle{}
+	vod, err := ValuesOrDefaults(vals, b)
+	is.NoError(err)
+	is.Len(vod, 0)
+}
+
 func TestValuesOrDefaults_Required(t *testing.T) {
 	is := assert.New(t)
 	vals := map[string]interface{}{


### PR DESCRIPTION
bundle.ValuesOrDefaults failed with a panic due to a nil pointer dereference when no parameters are defined in the bundle passed to the function.