### PR TITLE
exclude Out from json marshalling in Operation

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -34,7 +34,7 @@ type Operation struct {
 	// Files contains files that should be injected into the invocation image.
 	Files map[string]string `json:"files"`
 	// Output stream for log messages from the driver
-	Out io.Writer
+	Out io.Writer `json:"-"`
 }
 
 // ResolvedCred is a credential that has been resolved and is ready for injection into the runtime.

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1,7 +1,10 @@
 package driver
 
 import (
+	"encoding/json"
 	"io/ioutil"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,4 +32,68 @@ func TestDebugDriver_Run(t *testing.T) {
 		Out:          ioutil.Discard,
 	}
 	is.NoError(d.Run(op))
+}
+
+func TestOperation_Unmarshall(t *testing.T) {
+	expectedOp := Operation{
+		Action:       "install",
+		Installation: "test",
+		Parameters: map[string]interface{}{
+			"param1": "value1",
+			"param2": "value2",
+		},
+		Image:     "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
+		ImageType: "docker",
+		Revision:  "01DDY0MT808KX0GGZ6SMXN4TW",
+		Environment: map[string]string{
+			"ENV1": "value1",
+			"ENV2": "value2",
+		},
+		Files: map[string]string{
+			"/cnab/app/image-map.json": "{}",
+		},
+	}
+	var op Operation
+	is := assert.New(t)
+	bytes, err := ioutil.ReadFile("../testdata/operations/valid-operation.json")
+	is.NoError(err, "Error reading from testdata/operations/valid-operation.json")
+	is.NoError(json.Unmarshal(bytes, &op), "Error unmarshalling operation")
+	is.NotNil(op, "Expected Operation not to be nil")
+	is.True(reflect.DeepEqual(expectedOp, op), "Validating value of unmarshalled operation failed")
+}
+
+func TestOperation_Marshall(t *testing.T) {
+	actualOp := Operation{
+		Action:       "install",
+		Installation: "test",
+		Parameters: map[string]interface{}{
+			"param1": "value1",
+			"param2": "value2",
+		},
+		Image:     "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
+		ImageType: "docker",
+		Revision:  "01DDY0MT808KX0GGZ6SMXN4TW",
+		Environment: map[string]string{
+			"ENV1": "value1",
+			"ENV2": "value2",
+		},
+		Files: map[string]string{
+			"/cnab/app/image-map.json": "{}",
+		},
+		Out: os.Stdout,
+	}
+	is := assert.New(t)
+	bytes, err := json.Marshal(actualOp)
+	is.NoError(err, "Error Marshalling actual operation to json")
+	is.NotNil(bytes, "Expected marshalled json not to be nil")
+	actualJSON := string(bytes)
+	var expectedOp Operation
+	bytes, err = ioutil.ReadFile("../testdata/operations/valid-operation.json")
+	is.NoError(err, "Error reading from testdata/operations/valid-operation.json")
+	is.NoError(json.Unmarshal(bytes, &expectedOp), "Error unmarshalling expected operation")
+	bytes, err = json.Marshal(expectedOp)
+	is.NoError(err, "Error Marshalling expected operation to json")
+	is.NotNil(bytes, "Expected marshalled json not to be nil")
+	expectedJSON := string(bytes)
+	is.True(actualJSON == expectedJSON)
 }

--- a/testdata/operations/valid-operation.json
+++ b/testdata/operations/valid-operation.json
@@ -1,0 +1,18 @@
+{
+    "installation_name": "test",
+    "revision": "01DDY0MT808KX0GGZ6SMXN4TW",
+    "action": "install",
+    "parameters": {
+        "param1": "value1",
+        "param2": "value2"
+    },
+    "image": "testing.azurecr.io/duffle/test:e8966c3c153a525775cbcddd46f778bed25650b4",
+    "image_type": "docker",
+    "environment": {
+        "ENV1": "value1",
+        "ENV2": "value2"
+    },
+    "files": {
+        "/cnab/app/image-map.json": "{}"
+    }
+}


### PR DESCRIPTION
fixes #47.

@jeremyrickard , @silvin-lubecki this replace #48 , now has marshall/unmarshall tests