### PR TITLE
Handle immutable parameters in Bundle.ValuesOrDefaults

### DIFF
--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -247,7 +247,7 @@ func TestValuesOrDefaults_Immutable(t *testing.T) {
 	}
 
 	_, err := ValuesOrDefaults(vals, currentVals, b)
-	is.Error(err)
+	is.EqualError(err, "parameter namespace is immutable and cannot be overridden with value new-ns")
 }
 
 func TestValidateVersionTag(t *testing.T) {


### PR DESCRIPTION
This PR introduces a breaking change in the Bundle.ValuesOrDefaults function signature by taking a map of current parameter values in order to handle the recently introduced `immutable` field in the bundle parameters description.

The patch verifies when a parameter value is set:
1. the parameter has the immutable field set in the bundle
2. there is a previously set value for this parameter (i.e. a value has been set during the initial installation of the bundle) 
3. the new and existing values of this parameter are not identical

In that case an error is returned.