### PR TITLE
feat(claim.go): add Outputs field to Claim struct

### DIFF
--- a/claim/claim.go
+++ b/claim/claim.go
@@ -42,6 +42,7 @@ type Claim struct {
 	Bundle        *bundle.Bundle            `json:"bundle"`
 	Result        Result                    `json:"result"`
 	Parameters    map[string]interface{}    `json:"parameters"`
+	Outputs       map[string]interface{}    `json:"outputs"`
 	Files         map[string]string         `json:"files"`
 	RelocationMap bundle.ImageRelocationMap `json:"relocationMap"`
 }
@@ -67,6 +68,7 @@ func New(name string) (*Claim, error) {
 			Status: StatusUnknown,
 		},
 		Parameters:    map[string]interface{}{},
+		Outputs:       map[string]interface{}{},
 		RelocationMap: bundle.ImageRelocationMap{},
 	}, nil
 }

--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -17,6 +17,10 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, "my_claim", claim.Name, "Name is set")
 	assert.Equal(t, "unknown", claim.Result.Status)
 	assert.Equal(t, "unknown", claim.Result.Action)
+
+	assert.Equal(t, map[string]interface{}{}, claim.Outputs)
+	assert.Equal(t, map[string]interface{}{}, claim.Parameters)
+	assert.Equal(t, bundle.ImageRelocationMap{}, claim.RelocationMap)
 }
 
 func TestUpdate(t *testing.T) {


### PR DESCRIPTION
- add Outputs field to Claim struct, per cnab-spec (updated in https://github.com/deislabs/cnab-spec/pull/217)