### PR TITLE
chore(claim.go): remove unused Files field from Claim struct

### DIFF
--- a/claim/claim.go
+++ b/claim/claim.go
@@ -43,7 +43,6 @@ type Claim struct {
 	Result        Result                    `json:"result"`
 	Parameters    map[string]interface{}    `json:"parameters"`
 	Outputs       map[string]interface{}    `json:"outputs"`
-	Files         map[string]string         `json:"files"`
 	RelocationMap bundle.ImageRelocationMap `json:"relocationMap"`
 }
 


### PR DESCRIPTION
- remove Files field from Claim struct

I couldn't find any use of this field and it doesn't appear to be a part of the [claims spec](https://github.com/deislabs/cnab-spec/blob/master/400-claims.md).