### PR TITLE
Switch `digest` to `contentDigest` in the json tags

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -79,7 +79,7 @@ type LocationRef struct {
 type BaseImage struct {
 	ImageType string            `json:"imageType" mapstructure:"imageType"`
 	Image     string            `json:"image" mapstructure:"image"`
-	Digest    string            `json:"digest,omitempty" mapstructure:"digest"`
+	Digest    string            `json:"contentDigest,omitempty" mapstructure:"contentDigest"`
 	Size      uint64            `json:"size,omitempty" mapstructure:"size"`
 	Labels    map[string]string `json:"labels,omitempty" mapstructure:"labels"`
 	MediaType string            `json:"mediaType,omitempty" mapstructure:"mediaType"`

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -621,14 +621,17 @@ func TestDigestPresent(t *testing.T) {
 	bundle, err := Unmarshal(bun)
 	require.NoError(t, err, "the bundle should have been valid")
 
-	//invocationImages[] should have exactly 1 value
 	require.Equal(t, 1, len(bundle.InvocationImages), "there should be one invocation image in the bundle")
-	//the invocation image digest should equal sha256:aaaaaaa...
-	assert.Equal(t, "sha256:aaaaaaa...", bundle.InvocationImages[0].Digest)
+	assert.Equal(t,
+		"sha256:decafbad71b4175951f29eb96035604c8cc372c99affa2e6d05cde6e8e20cc9a",
+		bundle.InvocationImages[0].Digest,
+	)
 
-	//images[] should have exactly 1 values
-	_, ok := bundle.Images["my-microservice"]
+	image, ok := bundle.Images["my-microservice"]
 	require.True(t, ok, "there should been an image named my-microservice in the bundle")
-	// the image digest should equal sha256:aaaaaaaaaaaa...
-	assert.Equal(t, "sha256:aaaaaaaaaaaa...", bundle.Images["my-microservice"].Digest)
+	assert.Equal(
+		t,
+		"sha256:beefcacef6c04336a17761db2004813982abe0e87ab727a376c291e09391ea61",
+		image.Digest,
+	)
 }

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -613,3 +613,22 @@ func TestBundle_RoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestDigestPresent(t *testing.T) {
+	bun, err := ioutil.ReadFile("../testdata/bundles/digest.json")
+	require.NoError(t, err, "couldn't read test bundle")
+
+	bundle, err := Unmarshal(bun)
+	require.NoError(t, err, "the bundle should have been valid")
+
+	//invocationImages[] should have exactly 1 value
+	require.Equal(t, 1, len(bundle.InvocationImages), "there should be one invocation image in the bundle")
+	//the invocation image digest should equal sha256:aaaaaaa...
+	assert.Equal(t, "sha256:aaaaaaa...", bundle.InvocationImages[0].Digest)
+
+	//images[] should have exactly 1 values
+	_, ok := bundle.Images["my-microservice"]
+	require.True(t, ok, "there should been an image named my-microservice in the bundle")
+	// the image digest should equal sha256:aaaaaaaaaaaa...
+	assert.Equal(t, "sha256:aaaaaaaaaaaa...", bundle.Images["my-microservice"].Digest)
+}

--- a/testdata/bundles/digest.json
+++ b/testdata/bundles/digest.json
@@ -4,14 +4,14 @@
   "schemaVersion": "99.99",
   "images": {
     "my-microservice": {
-      "contentDigest": "sha256:aaaaaaaaaaaa...",
+      "contentDigest": "sha256:beefcacef6c04336a17761db2004813982abe0e87ab727a376c291e09391ea61",
       "description": "my microservice",
       "image": "technosophos/microservice:1.2.3"
     }
   },
   "invocationImages": [
     {
-      "contentDigest": "sha256:aaaaaaa...",
+      "contentDigest": "sha256:decafbad71b4175951f29eb96035604c8cc372c99affa2e6d05cde6e8e20cc9a",
       "image": "technosophos/helloworld:0.1.0",
       "imageType": "docker"
     }

--- a/testdata/bundles/digest.json
+++ b/testdata/bundles/digest.json
@@ -1,0 +1,67 @@
+{
+  "name": "foo",
+  "version": "1.0",
+  "schemaVersion": "99.99",
+  "images": {
+    "my-microservice": {
+      "contentDigest": "sha256:aaaaaaaaaaaa...",
+      "description": "my microservice",
+      "image": "technosophos/microservice:1.2.3"
+    }
+  },
+  "invocationImages": [
+    {
+      "contentDigest": "sha256:aaaaaaa...",
+      "image": "technosophos/helloworld:0.1.0",
+      "imageType": "docker"
+    }
+  ],
+  "credentials": {
+      "foo": {
+          "path": "pfoo"
+      },
+      "bar": {
+          "env": "ebar"
+      },
+      "quux": {
+          "path": "pquux",
+          "env": "equux"
+      }
+  },
+  "custom": {
+      "com.example.duffle-bag": {
+          "icon": "https://example.com/icon.png",
+          "iconType": "PNG"
+      },
+      "com.example.backup-preferences": {
+          "enabled": true,
+          "frequency": "daily"
+      }
+  },
+  "definitions" : {
+      "complexThing" : {
+          "type" : "object",
+          "properties" : {
+              "host" : {
+                  "default" : "localhost",
+                  "type" : "string",
+                  "minLength" : 3,
+                  "maxLength" : 10
+              },
+              "port" : {
+                  "type" : "integer",
+                  "minimum": 8000
+              }
+          },
+          "required" : ["port"]
+      }
+  },
+  "parameters" : {
+      "serverConfig" : {
+          "definition" : "complexThing",
+          "destination" : {
+              "path": "/cnab/is/go"
+          }
+      }
+  }
+}


### PR DESCRIPTION
This PR swaps `contentDigest` in place of `digest` in the json/mapstructure tags for the BaseImage type. Adds a test for marashalling as well.

Fixes #59