### PR TITLE
CODEOWNERS update

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of Duffle
-CODEOWNERS @technosophos @michellenoorali @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
-LICENSE    @technosophos @michellenoorali @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
-NOTICE     @technosophos @michellenoorali @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
+CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
+LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki
+NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki


### PR DESCRIPTION
@michelleN  has moved to a new team in Microsoft and isn't working on CNAB related things anymore, so this removes her from the CODEOWNERS file so she doesn't get any unneeded notifications from github.

A fond farewell to @michelleN 👋