### PR TITLE
Remove omitEmpty from Outputs Path

### DIFF
--- a/bundle/outputs.go
+++ b/bundle/outputs.go
@@ -8,5 +8,5 @@ type OutputDefinition struct {
 	Definition  string   `json:"definition" mapstructure:"definition"`
 	ApplyTo     []string `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
 	Description string   `json:"description,omitempty" mapstructure:"description"`
-	Path        string   `json:"path,omitemtpty" mapstructure:"path,omitempty"`
+	Path        string   `json:"path" mapstructure:"path"`
 }


### PR DESCRIPTION
Path is required in an output definition, so this removes the omitEmpty tag
from the JSON/mapstructure business.

Fixes #69