### PR TITLE
command-windows referenced old interface from duffle (CommandDriver)

### DIFF
--- a/driver/command/command_windows.go
+++ b/driver/command/command_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CheckDriverExists checks to see if the named driver exists
-func (d *CommandDriver) CheckDriverExists() bool {
+func (d *Driver) CheckDriverExists() bool {
 	cmd := exec.Command("where", d.cliName())
 	cmd.Env = os.Environ()
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Noticed this when I was updating Duffle. 