### PR TITLE
feat(bundle.go): add RequiredExtensions

### DIFF
--- a/testdata/bundles/foo.json
+++ b/testdata/bundles/foo.json
@@ -77,5 +77,8 @@
                 "path": "/cnab/is/go"
             }
         }
-    }
+    },
+    "requiredExtensions": [
+      "com.example.duffle-bag"
+    ]
 }


### PR DESCRIPTION
- adds the `RequiredExtensions` string array field to the `Bundle` struct, per the CNAB Spec (added in https://github.com/deislabs/cnab-spec/pull/220)

Closes #71 