### PR TITLE
Publish initial test coverage results to Azure Pipelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ HAS_GOLANGCI     := $(shell $(CHECK) golangci-lint)
 HAS_GOIMPORTS    := $(shell $(CHECK) goimports)
 GOLANGCI_VERSION := v1.16.0
 
+HAS_GOCOV_XML := $(shell command -v gocov-xml;)
+HAS_GOCOV := $(shell command -v gocov;)
+HAS_GO_JUNIT_REPORT := $(shell command -v go-junit-report;)
+
 
 .PHONY: bootstrap
 bootstrap:
@@ -39,3 +43,19 @@ ifndef HAS_GOIMPORTS
 	go get -u golang.org/x/tools/cmd/goimports
 endif
 	dep ensure -vendor-only -v
+
+ifndef HAS_GOCOV_XML
+	go get github.com/AlekSi/gocov-xml
+endif
+ifndef HAS_GOCOV
+	go get -u github.com/axw/gocov/gocov
+endif
+ifndef HAS_GO_JUNIT_REPORT
+	go get github.com/jstemmer/go-junit-report
+endif
+
+.PHONY: coverage
+coverage:
+	go test -v -coverprofile=coverage.txt -covermode count ./... 2>&1 | go-junit-report > report.xml
+	gocov convert coverage.txt > coverage.json
+	gocov-xml < coverage.json > coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cnab-go
 
+[![Build Status](https://dev.azure.com/deislabs/cnab-go/_apis/build/status/cnab-go?branchName=master)](https://dev.azure.com/deislabs/cnab-go/_build/latest?definitionId=14&branchName=master) ![Azure Pipelines coverage](https://img.shields.io/azure-devops/coverage/deislabs/cnab-go/14?logo=Azure%20Pipelines&style=flat)
+
 cnab-go is a library for building [CNAB](https://github.com/deislabs/cnab-spec) clients. It provides the building blocks relevant to the CNAB specification so that you may build tooling without needing to implement all aspects of the CNAB specification.
 
 cnab-go is currently being used by [Docker App](https://github.com/docker/app), [Duffle](https://github.com/deislabs/duffle), and [Porter](https://github.com/deislabs/porter). If you'd like to see your CNAB project listed here, please submit a PR.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,16 @@ steps:
 - script: |
     go version
     go get -v -t -d ./...
-    make bootstrap build test lint
+    make bootstrap build test lint coverage
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies, build, test'
+
+- task: PublishTestResults@2
+  inputs:
+    testRunner: JUnit
+    testResultsFiles: $(System.DefaultWorkingDirectory)/**/report.xml
+
+- task: PublishCodeCoverageResults@1
+  inputs:
+    codeCoverageTool: Cobertura 
+    summaryFileLocation: $(System.DefaultWorkingDirectory)/**/coverage.xml


### PR DESCRIPTION
Test of pushing code coverage results to Azure Pipelines.

See https://dev.azure.com/deislabs/cnab-go/_build/results?buildId=2510&view=results

Readme now looks like:

![image](https://user-images.githubusercontent.com/13103165/62650627-f67e1300-b95f-11e9-8f40-5bf267faee02.png)


The main reasons for trying this:

- we need code coverage results
- we are already using Azure Pipelines for this repo

That being said, I'm more than happy to look at other services for this (Coveralls, Codecov), although I haven't used them before - so suggestions are welcome :)