### PR TITLE
ref(bundle/*): replace mapstructure tags with yaml tags

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -16,25 +16,25 @@ import (
 
 // Bundle is a CNAB metadata document
 type Bundle struct {
-	SchemaVersion      string                 `json:"schemaVersion" mapstructure:"schemaVersion"`
-	Name               string                 `json:"name" mapstructure:"name"`
-	Version            string                 `json:"version" mapstructure:"version"`
-	Description        string                 `json:"description" mapstructure:"description"`
-	Keywords           []string               `json:"keywords,omitempty" mapstructure:"keywords"`
-	Maintainers        []Maintainer           `json:"maintainers,omitempty" mapstructure:"maintainers"`
-	InvocationImages   []InvocationImage      `json:"invocationImages" mapstructure:"invocationImages"`
-	Images             map[string]Image       `json:"images,omitempty" mapstructure:"images"`
-	Actions            map[string]Action      `json:"actions,omitempty" mapstructure:"actions"`
-	Parameters         map[string]Parameter   `json:"parameters,omitempty" mapstructure:"parameters"`
-	Credentials        map[string]Credential  `json:"credentials,omitempty" mapstructure:"credentials"`
-	Outputs            map[string]Output      `json:"outputs,omitempty" mapstructure:"outputs"`
-	Definitions        definition.Definitions `json:"definitions,omitempty" mapstructure:"definitions"`
-	License            string                 `json:"license,omitempty" mapstructure:"license"`
-	RequiredExtensions []string               `json:"requiredExtensions,omitempty" mapstructure:"requiredExtensions"`
+	SchemaVersion      string                 `json:"schemaVersion" yaml:"schemaVersion"`
+	Name               string                 `json:"name" yaml:"name"`
+	Version            string                 `json:"version" yaml:"version"`
+	Description        string                 `json:"description" yaml:"description"`
+	Keywords           []string               `json:"keywords,omitempty" yaml:"keywords,omitempty"`
+	Maintainers        []Maintainer           `json:"maintainers,omitempty" yaml:"maintainers,omitempty"`
+	InvocationImages   []InvocationImage      `json:"invocationImages" yaml:"invocationImages"`
+	Images             map[string]Image       `json:"images,omitempty" yaml:"images,omitempty"`
+	Actions            map[string]Action      `json:"actions,omitempty" yaml:"actions,omitempty"`
+	Parameters         map[string]Parameter   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Credentials        map[string]Credential  `json:"credentials,omitempty" yaml:"credentials,omitempty"`
+	Outputs            map[string]Output      `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	Definitions        definition.Definitions `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+	License            string                 `json:"license,omitempty" yaml:"license,omitempty"`
+	RequiredExtensions []string               `json:"requiredExtensions,omitempty" yaml:"requiredExtensions,omitempty"`
 
 	// Custom extension metadata is a named collection of auxiliary data whose
 	// meaning is defined outside of the CNAB specification.
-	Custom map[string]interface{} `json:"custom,omitempty" mapstructure:"custom"`
+	Custom map[string]interface{} `json:"custom,omitempty" yaml:"custom,omitempty"`
 }
 
 //Unmarshal unmarshals a Bundle that was not signed.
@@ -72,30 +72,30 @@ func (b Bundle) WriteTo(w io.Writer) (int64, error) {
 
 // LocationRef specifies a location within the invocation package
 type LocationRef struct {
-	Path      string `json:"path" mapstructure:"path"`
-	Field     string `json:"field" mapstructure:"field"`
-	MediaType string `json:"mediaType" mapstructure:"mediaType"`
+	Path      string `json:"path" yaml:"path"`
+	Field     string `json:"field" yaml:"field"`
+	MediaType string `json:"mediaType" yaml:"mediaType"`
 }
 
 // BaseImage contains fields shared across image types
 type BaseImage struct {
-	ImageType string            `json:"imageType" mapstructure:"imageType"`
-	Image     string            `json:"image" mapstructure:"image"`
-	Digest    string            `json:"contentDigest,omitempty" mapstructure:"contentDigest"`
-	Size      uint64            `json:"size,omitempty" mapstructure:"size"`
-	Labels    map[string]string `json:"labels,omitempty" mapstructure:"labels"`
-	MediaType string            `json:"mediaType,omitempty" mapstructure:"mediaType"`
+	ImageType string            `json:"imageType" yaml:"imageType"`
+	Image     string            `json:"image" yaml:"image"`
+	Digest    string            `json:"contentDigest,omitempty" yaml:"contentDigest"`
+	Size      uint64            `json:"size,omitempty" yaml:"size,omitempty"`
+	Labels    map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	MediaType string            `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
 }
 
 // Image describes a container image in the bundle
 type Image struct {
-	BaseImage   `mapstructure:",squash"`
-	Description string `json:"description" mapstructure:"description"` //TODO: change? see where it's being used? change to description?
+	BaseImage   `yaml:",inline"`
+	Description string `json:"description" yaml:"description"` //TODO: change? see where it's being used? change to description?
 }
 
 // InvocationImage contains the image type and location for the installation of a bundle
 type InvocationImage struct {
-	BaseImage `mapstructure:",squash"`
+	BaseImage `yaml:",inline"`
 }
 
 // ImageRelocationMap stores the relocated images
@@ -108,18 +108,18 @@ type ImageRelocationMap map[string]string
 //
 // A location may be either a file (by path) or an environment variable.
 type Location struct {
-	Path                string `json:"path,omitempty" mapstructure:"path"`
-	EnvironmentVariable string `json:"env,omitempty" mapstructure:"env"`
+	Path                string `json:"path,omitempty" yaml:"path,omitempty"`
+	EnvironmentVariable string `json:"env,omitempty" yaml:"env,omitempty"`
 }
 
 // Maintainer describes a code maintainer of a bundle
 type Maintainer struct {
 	// Name is a user name or organization name
-	Name string `json:"name" mapstructure:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Email is an optional email address to contact the named maintainer
-	Email string `json:"email,omitempty" mapstructure:"email"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
 	// Url is an optional URL to an address for the named maintainer
-	URL string `json:"url,omitempty" mapstructure:"url"`
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
 // Action describes a custom (non-core) action.
@@ -127,11 +127,11 @@ type Action struct {
 	// Modifies indicates whether this action modifies the release.
 	//
 	// If it is possible that an action modify a release, this must be set to true.
-	Modifies bool `json:"modifies,omitempty" mapstructure:"modifies"`
+	Modifies bool `json:"modifies,omitempty" yaml:"modifies,omitempty"`
 	// Stateless indicates that the action is purely informational, that credentials are not required, and that the runtime should not keep track of its invocation
-	Stateless bool `json:"stateless,omitempty" mapstructure:"stateless"`
+	Stateless bool `json:"stateless,omitempty" yaml:"stateless,omitempty"`
 	// Description describes the action as a user-readable string
-	Description string `json:"description,omitempty" mapstructure:"description"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // ValuesOrDefaults returns parameter values or the default parameter values. An error is returned when the parameter value does not pass

--- a/bundle/credentials.go
+++ b/bundle/credentials.go
@@ -2,7 +2,7 @@ package bundle
 
 // Credential represents the definition of a CNAB credential
 type Credential struct {
-	Location    `mapstructure:",squash"`
-	Description string `json:"description,omitempty" mapstructure:"description"`
-	Required    bool   `json:"required,omitempty" mapstructure:"required"`
+	Location    `yaml:",inline"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool   `json:"required,omitempty" yaml:"required,omitempty"`
 }

--- a/bundle/definition/schema.go
+++ b/bundle/definition/schema.go
@@ -13,51 +13,51 @@ type Definitions map[string]*Schema
 
 // Schema represents a JSON Schema compatible CNAB Definition
 type Schema struct {
-	Schema               string                 `json:"$schema,omitempty" yaml:"$schema,omitempty" mapstructure:"$schema,omitempty"`
-	Comment              string                 `json:"$comment,omitempty" yaml:"$comment,omitempty" mapstructure:"$comment,omitempty"`
-	ID                   string                 `json:"$id,omitempty" yaml:"$id,omitempty" mapstructure:"$id,omitempty"`
-	Ref                  string                 `json:"$ref,omitempty" yaml:"$ref,omitempty" mapstructure:"$ref,omitempty"`
-	AdditionalItems      interface{}            `json:"additionalItems,omitempty" yaml:"additionalItems,omitempty" mapstructure:"additionalItems,omitempty"`
-	AdditionalProperties interface{}            `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty" mapstructure:"additionalProperties,omitempty"`
-	AllOf                []*Schema              `json:"allOf,omitempty" yaml:"allOf,omitempty" mapstructure:"allOf,omitempty"`
-	Const                interface{}            `json:"const,omitempty" yaml:"const,omitempty" mapstructure:"const,omitempty"`
-	Contains             *Schema                `json:"contains,omitempty" yaml:"contains,omitempty" mapstructure:"contains,omitempty"`
-	ContentEncoding      string                 `json:"contentEncoding,omitempty" yaml:"contentEncoding,omitempty" mapstructure:"contentEncoding,omitempty"`
-	ContentMediaType     string                 `json:"contentMediaType,omitempty" yaml:"contentMediaType,omitempty" mapstructure:"contentMediaType,omitempty"`
-	Default              interface{}            `json:"default,omitempty" yaml:"default,omitempty" mapstructure:"default,omitempty"`
-	Definitions          Definitions            `json:"definitions,omitempty" yaml:"definitions,omitempty" mapstructure:"definitions,omitempty"`
-	Dependencies         map[string]interface{} `json:"dependencies,omitempty" yaml:"dependencies,omitempty" mapstructure:"dependencies,omitempty"`
-	Description          string                 `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
-	Else                 *Schema                `json:"else,omitempty" yaml:"else,omitempty" mapstructure:"else,omitempty"`
-	Enum                 []interface{}          `json:"enum,omitempty" yaml:"enum,omitempty" mapstructure:"enum,omitempty"`
-	Examples             []interface{}          `json:"examples,omitempty" yaml:"examples,omitempty" mapstructure:"examples,omitempty"`
-	ExclusiveMaximum     *float64               `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty" mapstructure:"exclusiveMaximum,omitempty"`
-	ExclusiveMinimum     *float64               `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty" mapstructure:"exclusiveMinimum,omitempty"`
-	Format               string                 `json:"format,omitempty" yaml:"format,omitempty" mapstructure:"format,omitempty"`
-	If                   *Schema                `json:"if,omitempty" yaml:"if,omitempty" mapstructure:"if,omitempty"`
+	Schema               string                 `json:"$schema,omitempty" yaml:"$schema,omitempty"`
+	Comment              string                 `json:"$comment,omitempty" yaml:"$comment,omitempty"`
+	ID                   string                 `json:"$id,omitempty" yaml:"$id,omitempty"`
+	Ref                  string                 `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	AdditionalItems      interface{}            `json:"additionalItems,omitempty" yaml:"additionalItems,omitempty"`
+	AdditionalProperties interface{}            `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
+	AllOf                []*Schema              `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	Const                interface{}            `json:"const,omitempty" yaml:"const,omitempty"`
+	Contains             *Schema                `json:"contains,omitempty" yaml:"contains,omitempty"`
+	ContentEncoding      string                 `json:"contentEncoding,omitempty" yaml:"contentEncoding,omitempty"`
+	ContentMediaType     string                 `json:"contentMediaType,omitempty" yaml:"contentMediaType,omitempty"`
+	Default              interface{}            `json:"default,omitempty" yaml:"default,omitempty"`
+	Definitions          Definitions            `json:"definitions,omitempty" yaml:"definitions,omitempty"`
+	Dependencies         map[string]interface{} `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Description          string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Else                 *Schema                `json:"else,omitempty" yaml:"else,omitempty"`
+	Enum                 []interface{}          `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Examples             []interface{}          `json:"examples,omitempty" yaml:"examples,omitempty"`
+	ExclusiveMaximum     *float64               `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	ExclusiveMinimum     *float64               `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	Format               string                 `json:"format,omitempty" yaml:"format,omitempty"`
+	If                   *Schema                `json:"if,omitempty" yaml:"if,omitempty"`
 	//Items can be a Schema or an Array of Schema :(
-	Items         interface{} `json:"items,omitempty" yaml:"items,omitempty" mapstructure:"items,omitempty"`
-	Maximum       *float64    `json:"maximum,omitempty" yaml:"maximum,omitempty" mapstructure:"maximum,omitempty"`
-	MaxLength     *float64    `json:"maxLength,omitempty" yaml:"maxLength,omitempty" mapstructure:"maxLength,omitempty"`
-	MinItems      *float64    `json:"minItems,omitempty" yaml:"minItems,omitempty" mapstructure:"minItems,omitempty"`
-	MinLength     *float64    `json:"minLength,omitempty" yaml:"minLength,omitempty" mapstructure:"minLength,omitempty"`
-	MinProperties *float64    `json:"minProperties,omitempty" yaml:"minProperties,omitempty" mapstructure:"minProperties,omitempty"`
-	Minimum       *float64    `json:"minimum,omitempty" yaml:"minimum,omitempty" mapstructure:"minimum,omitempty"`
-	MultipleOf    *float64    `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty" mapstructure:"multipleOf,omitempty"`
-	Not           *Schema     `json:"not,omitempty" yaml:"not,omitempty" mapstructure:"not,omitempty"`
-	OneOf         *Schema     `json:"oneOf,omitempty" yaml:"oneOf,omitempty" mapstructure:"oneOf,omitempty"`
+	Items         interface{} `json:"items,omitempty" yaml:"items,omitempty"`
+	Maximum       *float64    `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MaxLength     *float64    `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	MinItems      *float64    `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MinLength     *float64    `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MinProperties *float64    `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	Minimum       *float64    `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MultipleOf    *float64    `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Not           *Schema     `json:"not,omitempty" yaml:"not,omitempty"`
+	OneOf         *Schema     `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
 
-	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty" mapstructure:"patternProperties,omitempty"`
+	PatternProperties map[string]*Schema `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty"`
 
-	Properties    map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty" mapstructure:"properties,omitempty"`
-	PropertyNames *Schema            `json:"propertyNames,omitempty" yaml:"propertyNames,omitempty" mapstructure:"propertyNames,omitempty"`
-	ReadOnly      *bool              `json:"readOnly,omitempty" yaml:"readOnly,omitempty" mapstructure:"readOnly,omitempty"`
-	Required      []string           `json:"required,omitempty" yaml:"required,omitempty" mapstructure:"required,omitempty"`
-	Then          *Schema            `json:"then,omitempty" yaml:"then,omitempty" mapstructure:"then,omitempty"`
-	Title         string             `json:"title,omitempty" yaml:"title,omitempty" mapstructure:"title,omitempty"`
-	Type          interface{}        `json:"type,omitempty" yaml:"type,omitempty" mapstructure:"type,omitempty"`
-	UniqueItems   *bool              `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty" mapstructure:"uniqueItems,omitempty"`
-	WriteOnly     *bool              `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty" mapstructure:"writeOnly,omitempty"`
+	Properties    map[string]*Schema `json:"properties,omitempty" yaml:"properties,omitempty"`
+	PropertyNames *Schema            `json:"propertyNames,omitempty" yaml:"propertyNames,omitempty"`
+	ReadOnly      *bool              `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	Required      []string           `json:"required,omitempty" yaml:"required,omitempty"`
+	Then          *Schema            `json:"then,omitempty" yaml:"then,omitempty"`
+	Title         string             `json:"title,omitempty" yaml:"title,omitempty"`
+	Type          interface{}        `json:"type,omitempty" yaml:"type,omitempty"`
+	UniqueItems   *bool              `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	WriteOnly     *bool              `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
 }
 
 // GetType will return the singular type for a given schema and a success boolean. If the

--- a/bundle/outputs.go
+++ b/bundle/outputs.go
@@ -1,8 +1,8 @@
 package bundle
 
 type Output struct {
-	Definition  string   `json:"definition" mapstructure:"definition"`
-	ApplyTo     []string `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
-	Description string   `json:"description,omitempty" mapstructure:"description"`
-	Path        string   `json:"path" mapstructure:"path"`
+	Definition  string   `json:"definition" yaml:"definition"`
+	ApplyTo     []string `json:"applyTo,omitempty" yaml:"applyTo,omitempty"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Path        string   `json:"path" yaml:"path"`
 }

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -2,9 +2,9 @@ package bundle
 
 // Parameter defines a single parameter for a CNAB bundle
 type Parameter struct {
-	Definition  string    `json:"definition" mapstructure:"definition"`
-	ApplyTo     []string  `json:"applyTo,omitempty" mapstructure:"applyTo,omitempty"`
-	Description string    `json:"description,omitempty" mapstructure:"description"`
-	Destination *Location `json:"destination,omitemtpty" mapstructure:"destination"`
-	Required    bool      `json:"required,omitempty" mapstructure:"required,omitempty"`
+	Definition  string    `json:"definition" yaml:"definition"`
+	ApplyTo     []string  `json:"applyTo,omitempty" yaml:"applyTo,omitempty"`
+	Description string    `json:"description,omitempty" yaml:"description,omitempty"`
+	Destination *Location `json:"destination,omitemtpty" yaml:"destination,omitempty"`
+	Required    bool      `json:"required,omitempty" yaml:"required,omitempty"`
 }


### PR DESCRIPTION
Represents a possible dual closing of https://github.com/deislabs/cnab-go/issues/91 and adding yaml tags to all of the structs (per recent history of third-party use in https://github.com/deislabs/cnab-go/pull/90 and https://github.com/deislabs/cnab-go/pull/92; 92 could/would be superseded by this PR.)