### PR TITLE
feat(driver/lookup): add lookup pkg, Lookup method from duffle

### DIFF
--- a/driver/lookup/lookup.go
+++ b/driver/lookup/lookup.go
@@ -1,0 +1,29 @@
+package lookup
+
+import (
+	"fmt"
+
+	"github.com/deislabs/cnab-go/driver"
+	"github.com/deislabs/cnab-go/driver/command"
+	"github.com/deislabs/cnab-go/driver/docker"
+	"github.com/deislabs/cnab-go/driver/kubernetes"
+)
+
+// Lookup takes a driver name and tries to resolve the most pertinent driver.
+func Lookup(name string) (driver.Driver, error) {
+	switch name {
+	case "docker":
+		return &docker.Driver{}, nil
+	case "kubernetes", "k8s":
+		return &kubernetes.Driver{}, nil
+	case "debug":
+		return &driver.DebugDriver{}, nil
+	default:
+		cmddriver := &command.Driver{Name: name}
+		if cmddriver.CheckDriverExists() {
+			return cmddriver, nil
+		}
+
+		return nil, fmt.Errorf("unsupported driver or driver not found in PATH: %s", name)
+	}
+}


### PR DESCRIPTION
This transfers the `Lookup` method from [deislabs/duffle](https://github.com/deislabs/duffle/blob/master/pkg/driver/lookup.go) to this repo, in the continuing theme of moving generic/cnab-go-related logic into cnab-go itself (enabling third-party consumers to ideally only import cnab-go).

Assuming we merge, I can issue a follow-up PR in duffle to use this method from its new location here. (We should be able to delete duffle's entire [driver](https://github.com/deislabs/duffle/tree/master/pkg/driver) pkg in this case).

Note that I initially tried to add this `Lookup` method directly into `driver/driver.go`, but had to make extensive refactors to avoid cyclical imports (including creating a new package for the `Operation` and `OperationResult` structs currently in `driver.go`).  If we really want to avoid a new `lookup` package, that diff is here: https://github.com/deislabs/cnab-go/compare/master...vdice:ref/add-lookup-extract-operation?expand=1