### PR TITLE
ref(bundle): add ActionApplicable interface, AppliesTo methods to Parameter and Output

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -181,18 +181,6 @@ func getImageMap(b *bundle.Bundle) ([]byte, error) {
 	return json.Marshal(imgs)
 }
 
-func appliesToAction(action string, parameter bundle.Parameter) bool {
-	if len(parameter.ApplyTo) == 0 {
-		return true
-	}
-	for _, act := range parameter.ApplyTo {
-		if action == act {
-			return true
-		}
-	}
-	return false
-}
-
 func opFromClaim(action string, stateless bool, c *claim.Claim, ii bundle.InvocationImage, creds credentials.Set, w io.Writer) (*driver.Operation, error) {
 	env, files, err := creds.Expand(c.Bundle, stateless)
 	if err != nil {
@@ -246,7 +234,7 @@ func injectParameters(action string, c *claim.Claim, env, files map[string]strin
 	for k, param := range c.Bundle.Parameters {
 		rawval, ok := c.Parameters[k]
 		if !ok {
-			if param.Required && appliesToAction(action, param) {
+			if param.Required && param.AppliesTo(action) {
 				return fmt.Errorf("missing required parameter %q for action %q", k, action)
 			}
 			continue

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -223,3 +223,9 @@ func validateDockerish(s string) error {
 	}
 	return nil
 }
+
+// ActionApplicable is an interface for objects that may apply to a subset of actions
+// e.g., Parameters and Outputs
+type ActionApplicable interface {
+	AppliesTo(action string) bool
+}

--- a/bundle/outputs.go
+++ b/bundle/outputs.go
@@ -6,3 +6,17 @@ type Output struct {
 	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
 	Path        string   `json:"path" yaml:"path"`
 }
+
+// AppliesTo satisfies the ActionApplicable interface
+// by determining whether or not the Output applies to the provided action
+func (o *Output) AppliesTo(action string) bool {
+	if len(o.ApplyTo) == 0 {
+		return true
+	}
+	for _, act := range o.ApplyTo {
+		if action == act {
+			return true
+		}
+	}
+	return false
+}

--- a/bundle/outputs_test.go
+++ b/bundle/outputs_test.go
@@ -1,0 +1,29 @@
+package bundle
+
+import "testing"
+
+func TestOutputAppliesTo(t *testing.T) {
+	o := Output{}
+
+	// By default, output will apply to any action
+	if !o.AppliesTo("install") {
+		t.Errorf("Expected parameter to apply to action: install")
+	}
+
+	if !o.AppliesTo("status") {
+		t.Errorf("Expected parameter to apply to action: status")
+	}
+
+	o.ApplyTo = []string{
+		"install",
+		"uninstall",
+	}
+
+	if !o.AppliesTo("install") {
+		t.Errorf("Expected parameter to apply to action: install")
+	}
+
+	if o.AppliesTo("status") {
+		t.Errorf("Expected parameter to not apply to action: status")
+	}
+}

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -8,3 +8,17 @@ type Parameter struct {
 	Destination *Location `json:"destination,omitemtpty" yaml:"destination,omitempty"`
 	Required    bool      `json:"required,omitempty" yaml:"required,omitempty"`
 }
+
+// AppliesTo satisfies the ActionApplicable interface
+// by determining whether or not the Parameter applies to the provided action
+func (p *Parameter) AppliesTo(action string) bool {
+	if len(p.ApplyTo) == 0 {
+		return true
+	}
+	for _, act := range p.ApplyTo {
+		if action == act {
+			return true
+		}
+	}
+	return false
+}

--- a/bundle/parameters_test.go
+++ b/bundle/parameters_test.go
@@ -79,7 +79,33 @@ func TestCanReadParameterDefinition(t *testing.T) {
 	if p.ApplyTo[1] != action1 {
 		t.Errorf("Expected action '%s' but got '%s'", action1, p.ApplyTo[1])
 	}
-	if p.Required != true {
+	if !p.Required {
 		t.Errorf("Expected parameter to be required")
+	}
+}
+
+func TestParameterAppliesTo(t *testing.T) {
+	p := Parameter{}
+
+	// By default, parameter will apply to any action
+	if !p.AppliesTo("install") {
+		t.Errorf("Expected parameter to apply to action: install")
+	}
+
+	if !p.AppliesTo("status") {
+		t.Errorf("Expected parameter to apply to action: status")
+	}
+
+	p.ApplyTo = []string{
+		"install",
+		"uninstall",
+	}
+
+	if !p.AppliesTo("install") {
+		t.Errorf("Expected parameter to apply to action: install")
+	}
+
+	if p.AppliesTo("status") {
+		t.Errorf("Expected parameter to not apply to action: status")
 	}
 }


### PR DESCRIPTION
Add an `ActionApplicable` interface for objects that have the ability to apply to a set of actions (Parameter and Output, currently)