### PR TITLE
Properly handle optional credentials

### DIFF
--- a/credentials/credentialset.go
+++ b/credentials/credentialset.go
@@ -25,7 +25,7 @@ func (s Set) Expand(b *bundle.Bundle, stateless bool) (env, files map[string]str
 	for name, val := range b.Credentials {
 		src, ok := s[name]
 		if !ok {
-			if stateless {
+			if stateless || !val.Required {
 				continue
 			}
 			err = fmt.Errorf("credential %q is missing from the user-supplied credentials", name)
@@ -77,15 +77,15 @@ func Load(path string) (*CredentialSet, error) {
 
 // Validate compares the given credentials with the spec.
 //
-// This will result in an error only if:
-// - a parameter in the spec is not present in the given set
-// - a parameter in the given set does not match the format required by the spec
+// This will result in an error only when the following conditions are true:
+// - a credential in the spec is not present in the given set
+// - the credential is required
 //
 // It is allowed for spec to specify both an env var and a file. In such case, if
-// the givn set provides either, it will be considered valid.
+// the givesn set provides either, it will be considered valid.
 func Validate(given Set, spec map[string]bundle.Credential) error {
-	for name := range spec {
-		if !isValidCred(given, name) {
+	for name, cred := range spec {
+		if !isValidCred(given, name) && cred.Required {
 			return fmt.Errorf("bundle requires credential for %s", name)
 		}
 	}

--- a/credentials/credentialset_test.go
+++ b/credentials/credentialset_test.go
@@ -117,7 +117,26 @@ func TestCredentialSet_Merge(t *testing.T) {
 
 }
 
-func TestCredentialSetMissingCred(t *testing.T) {
+func TestCredentialSetMissingRequiredCred(t *testing.T) {
+	b := &bundle.Bundle{
+		Name: "knapsack",
+		Credentials: map[string]bundle.Credential{
+			"first": {
+				Location: bundle.Location{
+					EnvironmentVariable: "FIRST_VAR",
+				},
+				Required: true,
+			},
+		},
+	}
+	cs := Set{}
+	_, _, err := cs.Expand(b, false)
+	assert.EqualError(t, err, `credential "first" is missing from the user-supplied credentials`)
+	_, _, err = cs.Expand(b, true)
+	assert.NoError(t, err)
+}
+
+func TestCredentialSetMissingOptionalCred(t *testing.T) {
 	b := &bundle.Bundle{
 		Name: "knapsack",
 		Credentials: map[string]bundle.Credential{
@@ -130,7 +149,7 @@ func TestCredentialSetMissingCred(t *testing.T) {
 	}
 	cs := Set{}
 	_, _, err := cs.Expand(b, false)
-	assert.EqualError(t, err, `credential "first" is missing from the user-supplied credentials`)
+	assert.NoError(t, err)
 	_, _, err = cs.Expand(b, true)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
A credential has a `required` flag, which defaults to `true`. As #108 and the spec point out:

```
required indicates whether this credential MUST be supplied. By default it is false, which means the credential is optional. When true, a runtime MUST fail if the credential is not provided.
```

However, we were ALWAYS requiring any credential to have a value provided. This check occurred both in the CredentialSet Validate(..) method for that is used for stateful actions, but also the Expand(...) method. The Expand(..) method had an argument to flag an call to the method as stateless, in which case we allowed a credential to not be present but we still failed on optional for stateful calls. 

This PR adds explicit handling for optional credentials. 

Fixes #108