### PR TITLE
Allow installation names including "." character

### DIFF
--- a/claim/claim.go
+++ b/claim/claim.go
@@ -48,7 +48,7 @@ type Claim struct {
 }
 
 // ValidName is a regular expression that indicates whether a name is a valid claim name.
-var ValidName = regexp.MustCompile("^[a-zA-Z0-9_-]+$")
+var ValidName = regexp.MustCompile("^[a-zA-Z0-9._-]+$")
 
 // New creates a new Claim initialized for an installation operation.
 func New(name string) (*Claim, error) {

--- a/claim/claim_test.go
+++ b/claim/claim_test.go
@@ -45,18 +45,23 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestValidName(t *testing.T) {
-	is := assert.New(t)
-
 	for name, expect := range map[string]bool{
 		"M4cb3th":               true,
-		"Lady MacBeth":          false, //spaces illegal
+		"Lady MacBeth":          false, // spaces illegal
 		"3_Witches":             true,
 		"Banquø":                false, // We could probably loosen this one up
 		"King-Duncan":           true,
 		"MacDuff@geocities.com": false,
 		"hecate":                true, // I wouldn't dare cross Hecate.
+		"foo bar baz":           false,
+		"foo.bar.baz":           true,
+		"foo-bar-baz":           true,
+		"foo_bar_baz":           true,
+		"":                      false,
 	} {
-		is.Equal(expect, ValidName.MatchString(name))
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, expect, ValidName.MatchString(name), "expected '%s' to be %t", name, expect)
+		})
 	}
 }
 


### PR DESCRIPTION
From the [docs](https://github.com/deislabs/cnab-spec/blob/cc78ad5f2f7f4fabce6247f02cafb786bc011e07/103-bundle-runtime.md#environment-variables):

> Installation names MUST consist of Graph Unicode characters and MAY be user-readable. The Unicode Graphic characters include letters, marks, numbers, punctuation, symbols, and spaces, from categories L, M, N, P, S, Zs.

This PR doesn't quite bring cnab-go up to spec, but does enable the use of installation names which include the `.` character (this supports our internal installation naming convention). If someone would like to school me in regex we can update this PR to be fully spec compliant. 😄 