### PR TITLE
Add Urvashi Reddy as a cnab-go maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of Duffle
-CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone
-LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone
-NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone
+CODEOWNERS @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy
+LICENSE    @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy
+NOTICE     @technosophos @vdice @radu-matei @jeremyrickard @carolynvs @bacongobbler @glyn @silvin-lubecki @jlegrone @youreddy


### PR DESCRIPTION
Pivotal's contributions for outputs in cnab-go and the Duffle driver were very important and they  have indicated they will continue to be involved in the spec, as well as Duffle and cnab-go development, so I'd like to nominate Urvashi  as a maintainer.