### PR TITLE
feat(*): populate applicable output values with defaults when necessary

### DIFF
--- a/bundle/outputs.go
+++ b/bundle/outputs.go
@@ -6,3 +6,17 @@ type Output struct {
 	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
 	Path        string   `json:"path" yaml:"path"`
 }
+
+// AppliesTo returns a boolean value specifying whether or not
+// the Output applies to the provided action
+func (output *Output) AppliesTo(action string) bool {
+	if len(output.ApplyTo) == 0 {
+		return true
+	}
+	for _, act := range output.ApplyTo {
+		if action == act {
+			return true
+		}
+	}
+	return false
+}

--- a/bundle/parameters.go
+++ b/bundle/parameters.go
@@ -8,3 +8,17 @@ type Parameter struct {
 	Destination *Location `json:"destination,omitemtpty" yaml:"destination,omitempty"`
 	Required    bool      `json:"required,omitempty" yaml:"required,omitempty"`
 }
+
+// AppliesTo returns a boolean value specifying whether or not
+// the Parameter applies to the provided action
+func (parameter *Parameter) AppliesTo(action string) bool {
+	if len(parameter.ApplyTo) == 0 {
+		return true
+	}
+	for _, act := range parameter.ApplyTo {
+		if action == act {
+			return true
+		}
+	}
+	return false
+}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -36,6 +36,8 @@ type Operation struct {
 	Outputs []string `json:"outputs"`
 	// Output stream for log messages from the driver
 	Out io.Writer `json:"-"`
+	// Bundle represents the bundle information for use by the operation
+	Bundle *bundle.Bundle
 }
 
 // ResolvedCred is a credential that has been resolved and is ready for injection into the runtime.


### PR DESCRIPTION
If an applicable output (read: applies to a given action) is missing after the operation completes, supply an entry with the output's default value, if/when the default exists.

Note that this has only been added to the Docker driver which appears to be the sole driver implementing outputs as of writing.

Closes https://github.com/deislabs/cnab-go/issues/122