### PR TITLE
Add support for outputs to command driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,7 @@ coverage:
 	go test -v -coverprofile=coverage.txt -covermode count ./... 2>&1 | go-junit-report > report.xml
 	gocov convert coverage.txt > coverage.json
 	gocov-xml < coverage.json > coverage.xml
+
+.PHONY: goimports
+goimports:
+	find . -name "*.go" | fgrep -v vendor/ | xargs goimports -w -local github.com/$(ORG)/$(PROJECT)

--- a/driver/command/command.go
+++ b/driver/command/command.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 
 	"github.com/deislabs/cnab-go/driver"
@@ -14,7 +16,8 @@ import (
 
 // Driver relies upon a system command to provide a driver implementation
 type Driver struct {
-	Name string
+	Name          string
+	outputDirName string
 }
 
 // Run executes the command
@@ -56,14 +59,27 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
 		added = append(added, k)
 	}
+	// Create a directory that can be used for outputs and then pass it as a command line argument
+	if len(op.Outputs) > 0 {
+		var err error
+		d.outputDirName, err = ioutil.TempDir("", "bundleoutput")
+		if err != nil {
+			return driver.OperationResult{}, err
+		}
+		defer os.RemoveAll(d.outputDirName)
+		// Set the env var CNAB_OUTPUT_DIR to the location of the folder
+		pairs = append(pairs, fmt.Sprintf("%s=%s", "CNAB_OUTPUT_DIR", d.outputDirName))
+		added = append(added, "CNAB_OUTPUT_DIR")
+	}
+
 	// CNAB_VARS is a list of variables we added to the env. This is to make
 	// it easier for shell script drivers to clone the env vars.
 	pairs = append(pairs, fmt.Sprintf("CNAB_VARS=%s", strings.Join(added, ",")))
-
 	data, err := json.Marshal(op)
 	if err != nil {
 		return driver.OperationResult{}, err
 	}
+
 	args := []string{}
 	cmd := exec.Command(d.cliName(), args...)
 	cmd.Dir, err = os.Getwd()
@@ -72,9 +88,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	}
 	cmd.Env = pairs
 	cmd.Stdin = bytes.NewBuffer(data)
-
 	// Make stdout and stderr from driver available immediately
-
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return driver.OperationResult{}, fmt.Errorf("Setting up output handling for driver (%s) failed: %v", d.Name, err)
@@ -90,6 +104,7 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 	if err != nil {
 		return driver.OperationResult{}, fmt.Errorf("Setting up error output handling for driver (%s) failed: %v", d.Name, err)
 	}
+
 	go func() {
 
 		// Errors not handled here as they only prevent output from the driver being shown, errors in the command execution are handled when command is executed
@@ -101,5 +116,59 @@ func (d *Driver) exec(op *driver.Operation) (driver.OperationResult, error) {
 		return driver.OperationResult{}, fmt.Errorf("Start of driver (%s) failed: %v", d.Name, err)
 	}
 
-	return driver.OperationResult{}, cmd.Wait()
+	if err = cmd.Wait(); err != nil {
+		return driver.OperationResult{}, fmt.Errorf("Command driver (%s) failed executing bundle: %v", d.Name, err)
+	}
+
+	result, err := d.getOperationResult(op)
+	if err != nil {
+		return driver.OperationResult{}, fmt.Errorf("Command driver (%s) failed getting operation result: %v", d.Name, err)
+	}
+	return result, nil
+}
+func (d *Driver) getOperationResult(op *driver.Operation) (driver.OperationResult, error) {
+	opResult := driver.OperationResult{
+		Outputs: map[string]string{},
+	}
+	if len(op.Outputs) == 0 {
+		return opResult, nil
+	}
+
+	for _, item := range op.Outputs {
+		// Check if a value is required for this output and get the default value if available
+		valueRequired, defaultValue, err := checkIfOutputValueRequired(item, op, opResult)
+		if err != nil {
+			return opResult, fmt.Errorf("Command driver (%s) failed checking if output value required for item: %s Error: %v", d.Name, item, err)
+		}
+
+		fileName := path.Join(d.outputDirName, item)
+		_, err = os.Stat(fileName)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// Set a default value if available and required otherwise fail
+				if valueRequired {
+					return opResult, fmt.Errorf("Command driver (%s) failed for item: %s no output value found and no default value set", d.Name, item)
+				}
+				opResult.Outputs[item] = defaultValue
+				continue
+			}
+			return opResult, fmt.Errorf("Command driver (%s) failed checking for output file: %s Error: %v", d.Name, item, err)
+		}
+
+		contents, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			return opResult, fmt.Errorf("Command driver (%s) failed reading output file: %s Error: %v", d.Name, item, err)
+		}
+
+		opResult.Outputs[item] = string(contents)
+	}
+	return opResult, nil
+}
+func checkIfOutputValueRequired(item string, op *driver.Operation, opResult driver.OperationResult) (bool, string, error) {
+	// TODO Check if the output is required by the action and write test to validate (requires update to op definition in https://github.com/deislabs/cnab-go/pull/129 to be merged )
+	// Until this check is inmplemented then all values are required for all bundles and actions
+	// Output default values and applies to are ignored by this driver until this function is implemented
+	// Function should return false if a output does not apply to an action or there is a default value (which it should return as the second return value)
+	return true, "", nil
+
 }

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -1,0 +1,85 @@
+// +build !windows
+
+package command
+
+import (
+	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/driver"
+	"github.com/stretchr/testify/assert"
+
+	"os"
+	"testing"
+)
+
+func TestCommandDriverOutputs(t *testing.T) {
+	content := `#!/bin/sh
+		mkdir -p "${CNAB_OUTPUT_DIR}/cnab/app/outputs"
+		echo "TEST_OUTPUT_1" >> "${CNAB_OUTPUT_DIR}/cnab/app/outputs/output1"
+		echo "TEST_OUTPUT_2" >> "${CNAB_OUTPUT_DIR}/cnab/app/outputs/output2"
+	`
+	name := "test-outputs-exist.sh"
+	testfunc := func(t *testing.T, cmddriver *Driver) {
+		if !cmddriver.CheckDriverExists() {
+			t.Fatalf("Expected driver %s to exist Driver Name %s ", name, cmddriver.Name)
+		}
+		op := driver.Operation{
+			Action:       "install",
+			Installation: "test",
+			Parameters:   map[string]interface{}{},
+			Image: bundle.InvocationImage{
+				BaseImage: bundle.BaseImage{
+					Image:     "cnab/helloworld:latest",
+					ImageType: "docker",
+				},
+			},
+			Revision:    "01DDY0MT808KX0GGZ6SMXN4TW",
+			Environment: map[string]string{},
+			Files: map[string]string{
+				"/cnab/app/image-map.json": "{}",
+			},
+			Outputs: []string{"/cnab/app/outputs/output1", "/cnab/app/outputs/output2"},
+			Out:     os.Stdout,
+		}
+		opResult, err := cmddriver.Run(&op)
+		if err != nil {
+			t.Fatalf("Driver Run failed %v", err)
+		}
+		assert.Equal(t, 2, len(opResult.Outputs), "Expecting two output files")
+		assert.Equal(t, map[string]string{
+			"/cnab/app/outputs/output1": "TEST_OUTPUT_1\n",
+			"/cnab/app/outputs/output2": "TEST_OUTPUT_2\n",
+		}, opResult.Outputs)
+	}
+	CreateAndRunTestCommandDriver(t, name, content, testfunc)
+	content = `#!/bin/sh
+		mkdir -p "${CNAB_OUTPUT_DIR}/cnab/app/outputs"
+		echo "TEST_OUTPUT_1" >> "${CNAB_OUTPUT_DIR}/cnab/app/outputs/output1"
+	`
+	name = "test-outputs-missing.sh"
+	testfunc = func(t *testing.T, cmddriver *Driver) {
+		if !cmddriver.CheckDriverExists() {
+			t.Fatalf("Expected driver %s to exist Driver Name %s ", name, cmddriver.Name)
+		}
+		op := driver.Operation{
+			Action:       "install",
+			Installation: "test",
+			Parameters:   map[string]interface{}{},
+			Image: bundle.InvocationImage{
+				BaseImage: bundle.BaseImage{
+					Image:     "cnab/helloworld:latest",
+					ImageType: "docker",
+				},
+			},
+			Revision:    "01DDY0MT808KX0GGZ6SMXN4TW",
+			Environment: map[string]string{},
+			Files: map[string]string{
+				"/cnab/app/image-map.json": "{}",
+			},
+			Outputs: []string{"/cnab/app/outputs/output1", "/cnab/app/outputs/output2"},
+			Out:     os.Stdout,
+		}
+		_, err := cmddriver.Run(&op)
+		assert.Errorf(t, err, "Command driver (test-outputs-missing.sh) failed for item: /cnab/app/outputs/output2 no output value found and no default value set")
+	}
+	CreateAndRunTestCommandDriver(t, name, content, testfunc)
+}

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -3,13 +3,13 @@
 package command
 
 import (
+	"os"
+	"testing"
+
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/bundle/definition"
 	"github.com/deislabs/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
-
-	"os"
-	"testing"
 )
 
 func TestCommandDriverOutputs(t *testing.T) {

--- a/driver/command/command_nix_test.go
+++ b/driver/command/command_nix_test.go
@@ -4,6 +4,7 @@ package command
 
 import (
 	"github.com/deislabs/cnab-go/bundle"
+	"github.com/deislabs/cnab-go/bundle/definition"
 	"github.com/deislabs/cnab-go/driver"
 	"github.com/stretchr/testify/assert"
 
@@ -39,6 +40,22 @@ func TestCommandDriverOutputs(t *testing.T) {
 			},
 			Outputs: []string{"/cnab/app/outputs/output1", "/cnab/app/outputs/output2"},
 			Out:     os.Stdout,
+			Bundle: &bundle.Bundle{
+				Definitions: definition.Definitions{
+					"output1": &definition.Schema{},
+					"output2": &definition.Schema{},
+				},
+				Outputs: map[string]bundle.Output{
+					"output1": {
+						Definition: "output1",
+						Path:       "/cnab/app/outputs/output1",
+					},
+					"output2": {
+						Definition: "output2",
+						Path:       "/cnab/app/outputs/output2",
+					},
+				},
+			},
 		}
 		opResult, err := cmddriver.Run(&op)
 		if err != nil {
@@ -51,6 +68,7 @@ func TestCommandDriverOutputs(t *testing.T) {
 		}, opResult.Outputs)
 	}
 	CreateAndRunTestCommandDriver(t, name, content, testfunc)
+	// Test for an output missing and no defaults
 	content = `#!/bin/sh
 		mkdir -p "${CNAB_OUTPUT_DIR}/cnab/app/outputs"
 		echo "TEST_OUTPUT_1" >> "${CNAB_OUTPUT_DIR}/cnab/app/outputs/output1"
@@ -77,9 +95,82 @@ func TestCommandDriverOutputs(t *testing.T) {
 			},
 			Outputs: []string{"/cnab/app/outputs/output1", "/cnab/app/outputs/output2"},
 			Out:     os.Stdout,
+			Bundle: &bundle.Bundle{
+				Definitions: definition.Definitions{
+					"output1": &definition.Schema{},
+					"output2": &definition.Schema{},
+				},
+				Outputs: map[string]bundle.Output{
+					"output1": {
+						Definition: "output1",
+						Path:       "/cnab/app/outputs/output1",
+					},
+					"output2": {
+						Definition: "output2",
+						Path:       "/cnab/app/outputs/output2",
+					},
+				},
+			},
 		}
 		_, err := cmddriver.Run(&op)
 		assert.Errorf(t, err, "Command driver (test-outputs-missing.sh) failed for item: /cnab/app/outputs/output2 no output value found and no default value set")
+	}
+	CreateAndRunTestCommandDriver(t, name, content, testfunc)
+	// Test for an output missing with default value present
+	content = `#!/bin/sh
+		mkdir -p "${CNAB_OUTPUT_DIR}/cnab/app/outputs"
+		echo "TEST_OUTPUT_1" >> "${CNAB_OUTPUT_DIR}/cnab/app/outputs/output1"
+	`
+	name = "test-outputs-missing.sh"
+	testfunc = func(t *testing.T, cmddriver *Driver) {
+		if !cmddriver.CheckDriverExists() {
+			t.Fatalf("Expected driver %s to exist Driver Name %s ", name, cmddriver.Name)
+		}
+		op := driver.Operation{
+			Action:       "install",
+			Installation: "test",
+			Parameters:   map[string]interface{}{},
+			Image: bundle.InvocationImage{
+				BaseImage: bundle.BaseImage{
+					Image:     "cnab/helloworld:latest",
+					ImageType: "docker",
+				},
+			},
+			Revision:    "01DDY0MT808KX0GGZ6SMXN4TW",
+			Environment: map[string]string{},
+			Files: map[string]string{
+				"/cnab/app/image-map.json": "{}",
+			},
+			Outputs: []string{"/cnab/app/outputs/output1", "/cnab/app/outputs/output2"},
+			Out:     os.Stdout,
+			Bundle: &bundle.Bundle{
+				Definitions: definition.Definitions{
+					"output1": &definition.Schema{},
+					"output2": &definition.Schema{
+						Default: "DEFAULT OUTPUT 2",
+					},
+				},
+				Outputs: map[string]bundle.Output{
+					"output1": {
+						Definition: "output1",
+						Path:       "/cnab/app/outputs/output1",
+					},
+					"output2": {
+						Definition: "output2",
+						Path:       "/cnab/app/outputs/output2",
+					},
+				},
+			},
+		}
+		opResult, err := cmddriver.Run(&op)
+		if err != nil {
+			t.Fatalf("Driver Run failed %v", err)
+		}
+		assert.Equal(t, 2, len(opResult.Outputs), "Expecting two output files")
+		assert.Equal(t, map[string]string{
+			"/cnab/app/outputs/output1": "TEST_OUTPUT_1\n",
+			"/cnab/app/outputs/output2": "DEFAULT OUTPUT 2",
+		}, opResult.Outputs)
 	}
 	CreateAndRunTestCommandDriver(t, name, content, testfunc)
 }

--- a/driver/command/command_test.go
+++ b/driver/command/command_test.go
@@ -20,7 +20,16 @@ func TestCheckDriverExists(t *testing.T) {
 	}
 
 	name = "existing-driver"
-	cmddriver = &Driver{Name: name}
+	testfunc := func(t *testing.T, cmddriver *Driver) {
+		if !cmddriver.CheckDriverExists() {
+			t.Fatalf("Expected driver %s to exist", cmddriver.Name)
+		}
+
+	}
+	CreateAndRunTestCommandDriver(t, name, "", testfunc)
+}
+func CreateAndRunTestCommandDriver(t *testing.T, name string, content string, testfunc func(t *testing.T, d *Driver)) {
+	cmddriver := &Driver{Name: name}
 	dirname, err := ioutil.TempDir("", "cnab")
 	if err != nil {
 		t.Fatal(err)
@@ -33,14 +42,16 @@ func TestCheckDriverExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if len(content) > 0 {
+		newfile.WriteString(content)
+	}
+
 	newfile.Chmod(0755)
+	newfile.Close()
 	path := os.Getenv("PATH")
 	pathlist := []string{dirname, path}
 	newpath := strings.Join(pathlist, string(os.PathListSeparator))
 	defer os.Setenv("PATH", path)
 	os.Setenv("PATH", newpath)
-	if !cmddriver.CheckDriverExists() {
-		t.Fatalf("Expected driver %s to exist", name)
-	}
-
+	testfunc(t, cmddriver)
 }

--- a/driver/docker/docker_integration_test.go
+++ b/driver/docker/docker_integration_test.go
@@ -36,7 +36,7 @@ func TestDriver_Run(t *testing.T) {
 		Installation: "example",
 		Action:       "install",
 		Image:        image,
-		Outputs:      []string{
+		Outputs: []string{
 			"/cnab/app/outputs/output1",
 			"/cnab/app/outputs/output2",
 			"/cnab/app/outputs/missingApplicableOutputWithDefault",
@@ -65,7 +65,7 @@ func TestDriver_Run(t *testing.T) {
 				},
 				"missingNonApplicableOutputWithDefault": {
 					Definition: "missingApplicableOutputWithDefault",
-					ApplyTo: []string{"upgrade"},
+					ApplyTo:    []string{"upgrade"},
 				},
 			},
 		},
@@ -86,8 +86,8 @@ func TestDriver_Run(t *testing.T) {
 	assert.Equal(t, "Install action\nAction install complete for example\n", output.String())
 	assert.Equal(t, 3, len(opResult.Outputs), "Expecting three output files")
 	assert.Equal(t, map[string]string{
-		"/cnab/app/outputs/output1": "SOME INSTALL CONTENT 1\n",
-		"/cnab/app/outputs/output2": "SOME INSTALL CONTENT 2\n",
+		"/cnab/app/outputs/output1":                            "SOME INSTALL CONTENT 1\n",
+		"/cnab/app/outputs/output2":                            "SOME INSTALL CONTENT 2\n",
 		"/cnab/app/outputs/missingApplicableOutputWithDefault": "foo",
 	}, opResult.Outputs)
 }
@@ -115,7 +115,7 @@ func TestDriver_Run_MissingRequiredOutput(t *testing.T) {
 		Installation: "example",
 		Action:       "install",
 		Image:        image,
-		Outputs:      []string{
+		Outputs: []string{
 			"/cnab/app/outputs/missingApplicableOutputSansDefault",
 		},
 		Bundle: &bundle.Bundle{


### PR DESCRIPTION
Adds support for outputs to the command driver.

Command driver will create a temp folder for the driver process to write outputs to and pass the folder path to the driver process in the  environment variable CNAB_OUTPUT_DIR

fixes #84 