### PR TITLE
Support Pod annotations and node tolerations in Kubernetes Driver

### DIFF
--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -34,6 +34,7 @@ const (
 type Driver struct {
 	Namespace             string
 	ServiceAccountName    string
+	Annotations           map[string]string
 	LimitCPU              resource.Quantity
 	LimitMemory           resource.Quantity
 	Tolerations           []v1.Toleration
@@ -142,7 +143,8 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 			BackoffLimit:          &k.BackoffLimit,
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labelMap,
+					Labels:      labelMap,
+					Annotations: k.Annotations,
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName:           k.ServiceAccountName,

--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -36,6 +36,7 @@ type Driver struct {
 	ServiceAccountName    string
 	LimitCPU              resource.Quantity
 	LimitMemory           resource.Quantity
+	Tolerations           []v1.Toleration
 	ActiveDeadlineSeconds int64
 	BackoffLimit          int32
 	SkipCleanup           bool
@@ -147,6 +148,7 @@ func (k *Driver) Run(op *driver.Operation) (driver.OperationResult, error) {
 					ServiceAccountName:           k.ServiceAccountName,
 					AutomountServiceAccountToken: &mountServiceAccountToken,
 					RestartPolicy:                v1.RestartPolicyNever,
+					Tolerations:                  k.Tolerations,
 				},
 			},
 		},


### PR DESCRIPTION
These are both often important bits of configuration which can vary depending on the Kubernetes environment.