### PR TITLE
chore(packager/import.go): remove unused error, update issue location

### DIFF
--- a/packager/import.go
+++ b/packager/import.go
@@ -16,7 +16,6 @@ type Importer struct {
 	Source      string
 	Destination string
 	Loader      loader.BundleLoader
-	Verbose     bool
 }
 
 // NewImporter creates a new secure *Importer
@@ -29,7 +28,6 @@ func NewImporter(source, destination string, load loader.BundleLoader, verbose b
 		Source:      source,
 		Destination: destination,
 		Loader:      load,
-		Verbose:     verbose,
 	}, nil
 }
 

--- a/packager/import.go
+++ b/packager/import.go
@@ -23,12 +23,12 @@ type Importer struct {
 // source is the filesystem path to the archive.
 // destination is the directory to unpack the contents.
 // load is a loader.BundleLoader preconfigured for loading bundles.
-func NewImporter(source, destination string, load loader.BundleLoader, verbose bool) (*Importer, error) {
+func NewImporter(source, destination string, load loader.BundleLoader) *Importer {
 	return &Importer{
 		Source:      source,
 		Destination: destination,
 		Loader:      load,
-	}, nil
+	}
 }
 
 // Import decompresses a bundle from Source (location of the compressed bundle) and properly places artifacts in the correct location(s)

--- a/packager/import.go
+++ b/packager/import.go
@@ -1,7 +1,6 @@
 package packager
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,11 +9,6 @@ import (
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/deislabs/cnab-go/bundle/loader"
 	"github.com/docker/docker/pkg/archive"
-)
-
-var (
-	// ErrNoArtifactsDirectory indicates a missing artifacts/ directory
-	ErrNoArtifactsDirectory = errors.New("No artifacts/ directory found")
 )
 
 // Importer is responsible for importing a file
@@ -43,7 +37,7 @@ func NewImporter(source, destination string, load loader.BundleLoader, verbose b
 func (im *Importer) Import() error {
 	_, _, err := im.Unzip()
 
-	// TODO: https://github.com/deislabs/duffle/issues/758
+	// TODO: https://github.com/deislabs/cnab-go/issues/136
 
 	return err
 }
@@ -66,8 +60,7 @@ func (im *Importer) Unzip() (string, *bundle.Bundle, error) {
 		Compression:      archive.Gzip,
 		IncludeFiles:     []string{"."},
 		IncludeSourceDir: true,
-		// Issue #416
-		NoLchown: true,
+		NoLchown:         true,
 	}
 	if err := archive.Untar(reader, dest, tarOptions); err != nil {
 		return "", nil, fmt.Errorf("untar failed: %s", err)


### PR DESCRIPTION
A bit of cleanup after this logic was imported from deislabs/duffle...

- removes unused custom error
- updates TODO issue URL
- removes unused `Verbose` struct field
- updates the `NewImporter` func signature to just return an `*Importer` object (had previously always returned `nil` for the additional `error` type)