### PR TITLE
feat(bundle.go): add DeepCopy for InvocationImage/BaseImage/Image

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -87,15 +87,36 @@ type BaseImage struct {
 	MediaType string            `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
 }
 
+func (i *BaseImage) DeepCopy() *BaseImage {
+	i2 := *i
+	i2.Labels = make(map[string]string, len(i.Labels))
+	for key, value := range i.Labels {
+		i2.Labels[key] = value
+	}
+	return &i2
+}
+
 // Image describes a container image in the bundle
 type Image struct {
 	BaseImage   `yaml:",inline"`
 	Description string `json:"description" yaml:"description"` //TODO: change? see where it's being used? change to description?
 }
 
+func (i *Image) DeepCopy() *Image {
+	i2 := *i
+	i2.BaseImage = *i.BaseImage.DeepCopy()
+	return &i2
+}
+
 // InvocationImage contains the image type and location for the installation of a bundle
 type InvocationImage struct {
 	BaseImage `yaml:",inline"`
+}
+
+func (img *InvocationImage) DeepCopy() *InvocationImage {
+	img2 := *img
+	img2.BaseImage = *img.BaseImage.DeepCopy()
+	return &img2
 }
 
 // Location provides the location where a value should be written in

--- a/bundle/bundle_test.go
+++ b/bundle/bundle_test.go
@@ -648,3 +648,35 @@ func TestDigestPresent(t *testing.T) {
 		image.Digest,
 	)
 }
+
+func TestImageDeepCopy(t *testing.T) {
+	origImg := Image{
+		Description: "my image",
+		BaseImage: BaseImage{
+			Image:     "alpine",
+			ImageType: "docker",
+			Labels: map[string]string{
+				"origLabel": "origLabelValue",
+			},
+			Digest: "abc1234",
+			Size:   2,
+		},
+	}
+
+	newImg := origImg.DeepCopy()
+
+	newImg.Description = "my new image"
+	newImg.Image = "debian"
+	newImg.Labels["origLabel"] = "newLabelValue"
+	newImg.Digest = "123abcd"
+
+	assert.Equal(t, "my image", origImg.Description)
+	assert.Equal(t, "alpine", origImg.Image)
+	assert.Equal(t, map[string]string{"origLabel": "origLabelValue"}, origImg.Labels)
+	assert.Equal(t, "abc1234", origImg.Digest)
+
+	assert.Equal(t, "my new image", newImg.Description)
+	assert.Equal(t, "debian", newImg.Image)
+	assert.Equal(t, map[string]string{"origLabel": "newLabelValue"}, newImg.Labels)
+	assert.Equal(t, "123abcd", newImg.Digest)
+}


### PR DESCRIPTION
Adds a `DeepCopy` method on a `BaseImage` struct, used also for `DeepCopy` methods for the `InvocationImage` and `Image` structs.