### PR TITLE
fix(kubernetes): print logs when job fails

### DIFF
--- a/driver/kubernetes/kubernetes.go
+++ b/driver/kubernetes/kubernetes.go
@@ -283,16 +283,13 @@ func (k *Driver) watchJobStatusAndLogs(podSelector metav1.ListOptions, jobSelect
 			break
 		}
 	}
-	if err != nil {
-		return err
-	}
 
 	// Wait for pod logs to finish printing
 	for i := 0; i < int(k.requiredCompletions); i++ {
 		<-logsStreamingComplete
 	}
 
-	return nil
+	return err
 }
 
 func (k *Driver) streamPodLogs(options metav1.ListOptions, out io.Writer, done chan bool) error {


### PR DESCRIPTION
This PR updates the Kubernetes driver to stream Pod logs when the Job which executes the invocation image has failed.

This allows end users to debug their invocation images if an action execution does not succeed.